### PR TITLE
[feat] Modal(Dialog) 재사용뷰 구현

### DIFF
--- a/app/src/main/java/org/sopt/pingle/presentation/ui/common/AllModalDialogFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/common/AllModalDialogFragment.kt
@@ -1,4 +1,4 @@
-package org.sopt.pingle.util.component
+package org.sopt.pingle.presentation.ui.common
 
 import android.os.Bundle
 import android.view.View

--- a/app/src/main/java/org/sopt/pingle/util/component/AllModalDialogFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/util/component/AllModalDialogFragment.kt
@@ -1,0 +1,44 @@
+package org.sopt.pingle.util.component
+
+import android.os.Bundle
+import android.view.View
+import org.sopt.pingle.R
+import org.sopt.pingle.databinding.DialogAllModalBinding
+import org.sopt.pingle.util.base.BindingDialogFragment
+
+class AllModalDialogFragment(
+    private val title: String,
+    private val detail: String,
+    private val buttonText: String,
+    private val textButtonText: String,
+    private val clickBtn: () -> Unit,
+    private val clickTextBtn: () -> Unit
+) : BindingDialogFragment<DialogAllModalBinding>(R.layout.dialog_all_modal) {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        initLayout()
+        addListeners()
+    }
+
+    private fun initLayout() {
+        with(binding) {
+            tvAllModalTitle.text = title
+            tvAllModalDetail.text = detail
+            btnAllModalButton.text = buttonText
+            tvAllModalTextButton.text = textButtonText
+        }
+    }
+
+    private fun addListeners() {
+        binding.btnAllModalButton.setOnClickListener {
+            clickBtn()
+            dismiss()
+        }
+
+        binding.tvAllModalTextButton.setOnClickListener {
+            clickTextBtn()
+            dismiss()
+        }
+    }
+}

--- a/app/src/main/res/layout/dialog_all_modal.xml
+++ b/app/src/main/res/layout/dialog_all_modal.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/dialog_horizontal_margin"
+            android:background="@drawable/shape_border_radius_15"
+            android:backgroundTint="@color/g_10"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/gl_start"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                app:layout_constraintGuide_begin="@dimen/dialog_all_modal_horizontal_margin" />
+
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/gl_end"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                app:layout_constraintGuide_end="@dimen/dialog_all_modal_horizontal_margin" />
+
+            <TextView
+                android:id="@+id/tv_all_modal_title"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="46dp"
+                android:gravity="center"
+                android:textAppearance="@style/TextAppearance.Pingle.Sub.Semi.18"
+                android:textColor="@color/white"
+                app:layout_constraintEnd_toStartOf="@id/gl_end"
+                app:layout_constraintStart_toStartOf="@id/gl_start"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="제목" />
+
+            <TextView
+                android:id="@+id/tv_all_modal_detail"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:gravity="center"
+                android:textAppearance="@style/TextAppearance.Pingle.Body.Med.14"
+                android:textColor="@color/g_05"
+                app:layout_constraintEnd_toEndOf="@id/gl_end"
+                app:layout_constraintStart_toStartOf="@id/gl_start"
+                app:layout_constraintTop_toBottomOf="@id/tv_all_modal_title"
+                tools:text="세부 텍스트" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btn_all_modal_button"
+                style="@style/Theme.Pingle.Button.M"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="35dp"
+                android:layout_marginTop="33dp"
+                android:backgroundTint="@color/g_01"
+                android:textColor="@color/black"
+                app:layout_constraintEnd_toEndOf="@id/gl_end"
+                app:layout_constraintStart_toStartOf="@id/gl_start"
+                app:layout_constraintTop_toBottomOf="@id/tv_all_modal_detail"
+                tools:text="button" />
+
+            <TextView
+                android:id="@+id/tv_all_modal_text_button"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:layout_marginBottom="29dp"
+                android:gravity="center"
+                android:textAppearance="@style/TextAppearance.Pingle.Cap.Semi.12"
+                android:textColor="@color/g_01"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="@id/gl_end"
+                app:layout_constraintStart_toStartOf="@id/gl_start"
+                app:layout_constraintTop_toBottomOf="@id/btn_all_modal_button"
+                tools:text="button" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/dialog_all_modal.xml
+++ b/app/src/main/res/layout/dialog_all_modal.xml
@@ -70,7 +70,7 @@
                 android:layout_marginHorizontal="35dp"
                 android:layout_marginTop="33dp"
                 android:backgroundTint="@color/g_01"
-                android:textColor="@color/black"
+                android:textColor="@color/g_11"
                 app:layout_constraintEnd_toEndOf="@id/gl_end"
                 app:layout_constraintStart_toStartOf="@id/gl_start"
                 app:layout_constraintTop_toBottomOf="@id/tv_all_modal_detail"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -33,4 +33,7 @@
     <dimen name="button_l_height">56dp</dimen>
     <dimen name="button_m_height">42dp</dimen>
     <dimen name="button_s_height">42dp</dimen>
+
+    <dimen name="dialog_horizontal_margin">24dp</dimen>
+    <dimen name="dialog_all_modal_horizontal_margin">34dp</dimen>
 </resources>


### PR DESCRIPTION
## Related issue 🛠
- closed #10 

## Work Description ✏️
- Modal(Dialog) 재사용뷰를 구현했습니다.

## Screenshot 📸
<img width="261" alt="스크린샷 2024-01-05 오후 5 43 42" src="https://github.com/TeamPINGLE/PINGLE-ANDROID/assets/103172971/b320765b-4949-4ae1-99d5-da36c11cbf14">

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
- 메인 지도 뷰에서도 이 모달이 필요해서 제가 빠르게 작업했습니다,,, 제송합니둥 ㅠ
- 모달 생성 시 뜨는 backdrop은 메인 지도 뷰 참여모달을 구현할 때 구현했기 때문에 여기서는 따로 구현하지 않았습니다.
- 텍스트 버튼에 밑줄은 스트링 추출 하실 때 b 태그 넣어주시면 됩니다.