### PR TITLE
[mod] 번개 개최 뷰 - 날짜/시간 부분 수정

### DIFF
--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/plan/PlanDateTimeFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/plan/PlanDateTimeFragment.kt
@@ -5,10 +5,11 @@ import android.view.View
 import androidx.fragment.app.activityViewModels
 import java.text.SimpleDateFormat
 import java.time.LocalDate
+import java.util.Locale
 import org.sopt.pingle.R
 import org.sopt.pingle.databinding.FragmentPlanDateTimeBinding
 import org.sopt.pingle.util.base.BindingFragment
-import timber.log.Timber
+import org.sopt.pingle.util.component.CustomSnackbar
 
 class PlanDateTimeFragment :
     BindingFragment<FragmentPlanDateTimeBinding>(R.layout.fragment_plan_date_time) {
@@ -57,6 +58,11 @@ class PlanDateTimeFragment :
         if (selectedLocalDate != null) {
             if (selectedLocalDate.before(todayLocalDate)) {
                 // TODO 에러 스낵바 노출
+                CustomSnackbar.makeSnackbar(
+                    binding.root,
+                    getString(R.string.plan_future_date_snackber),
+                    126
+                )
             } else {
                 binding.includePlanTextWithTitleDate.tvText.text = String.format(
                     "%d년 %d월 %d일",
@@ -69,16 +75,37 @@ class PlanDateTimeFragment :
         }
     }
 
-    // TODO 시간 포맷 나오면 수정 예정
-    // TODO {} 수정 예정
-    private fun onTimeDialogFragmentClosed(time: String) {
+    private fun onTimeDialogFragmentClosed(meridiem: String, hour: Int, minute: Int) {
+        val time12Hour = String.format("%02d:%02d %s", hour, minute, meridiem)
         when (planViewModel.selectedTimeType.value) {
             START_TIME -> {
-                Timber.d(START_TIME)
+                binding.includePlanTextWithTitleStartTime.tvText.text =
+                    convert24HFormatHours(time12Hour, false)
+                planViewModel.setStartTime(convert24HFormatHours(time12Hour, true))
             }
 
             END_TIME -> {
-                Timber.d(END_TIME)
+                binding.includePlanTextWithTitleEndTime.tvText.text =
+                    convert24HFormatHours(time12Hour, false)
+                planViewModel.setEndTime(convert24HFormatHours(time12Hour, true))
+            }
+        }
+    }
+
+    private fun convert24HFormatHours(time12Hour: String, isWithSecond: Boolean): String {
+        val inputFormat = SimpleDateFormat("hh:mm a", Locale.US)
+        val outputFormat = SimpleDateFormat("HH:mm", Locale.getDefault())
+        val outputFormatWithSecond = SimpleDateFormat("HH:mm:ss", Locale.getDefault())
+
+        val date = inputFormat.parse(time12Hour)
+
+        return when (isWithSecond) {
+            false -> {
+                outputFormat.format(date)
+            }
+
+            true -> {
+                outputFormatWithSecond.format(date)
             }
         }
     }

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/plan/PlanTimeDialogFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/plan/PlanTimeDialogFragment.kt
@@ -9,7 +9,7 @@ import org.sopt.pingle.presentation.type.MeridiemType
 import org.sopt.pingle.util.base.BindingBottomSheetDialogFragment
 
 class PlanTimeDialogFragment(
-    private val onDialogClosed: (String) -> Unit
+    private val onDialogClosed: (meridiem: String, hour: Int, minute: Int) -> Unit
 ) :
     BindingBottomSheetDialogFragment<DialogTimePickerBinding>(R.layout.dialog_time_picker) {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -57,17 +57,13 @@ class PlanTimeDialogFragment(
 
     private fun addListeners() {
         binding.tvTimePickerDone.setOnClickListener {
-            onDialogClosed("aaa")
-            // 시간 설정 후 editText에 띄우기
-//            with(binding) {
-//                val timeFormat =
-//                    String.format("%02d:%02d:00", npTimePickerHour.value, npTimePickerMinute.value)
-//                onDialogClosed(timeFormat)
-//                Log.d(
-//                    "aaa",
-//                    String.format("%02d:%02d:00", npTimePickerHour.value, npTimePickerMinute.value)
-//                )
-//            }
+            with(binding) {
+                onDialogClosed(
+                    if (npTimePickerMeridiem.value == 0) MeridiemType.AM.name else MeridiemType.PM.name,
+                    npTimePickerHour.value,
+                    npTimePickerMinute.value
+                )
+            }
             dismiss()
         }
     }

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/plan/PlanViewModel.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/plan/PlanViewModel.kt
@@ -6,31 +6,53 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import org.sopt.pingle.presentation.type.PlanType
+import org.sopt.pingle.util.combineAll
 
 class PlanViewModel : ViewModel() {
     private val _currentPage = MutableStateFlow(FIRST_PAGE_POSITION)
     val currentPage get() = _currentPage.asStateFlow()
     val planTitle = MutableStateFlow("")
-    private val _planDate = MutableStateFlow<String?>(null)
+    private val _planDate = MutableStateFlow("")
     val planDate get() = _planDate.asStateFlow()
+    private val _startTime = MutableStateFlow("")
+    val startTime get() = _startTime.asStateFlow()
+    private val _endTime = MutableStateFlow("")
+    val endTime get() = _endTime.asStateFlow()
     private val _selectedTimeType = MutableStateFlow<String?>(null)
+
     val selectedTimeType get() = _selectedTimeType.asStateFlow()
     val planOpenChattingLink = MutableStateFlow("")
 
     // TODO Type에 맞게 수정(현재는 내가 맡은 부분 테스트를 위해 postion 값을 조정 및 임의 지정 해놓음
-    val isPlanBtnEnabled: StateFlow<Boolean> =
-        combine(
-            currentPage,
-            planTitle,
-            planOpenChattingLink
-        ) { currentPage, planTitle, planOpenChattingLink ->
+    val isPlanBtn =
+        listOf(currentPage, planTitle, planDate, startTime, endTime, planOpenChattingLink)
+            .combineAll()
+
+    // TODO 수정 예정, 테스트를 위해 position값 임의 설정
+    val isPlanBtnEnabled: StateFlow<Boolean> = listOf(
+        currentPage,
+        planTitle,
+        planDate,
+        startTime,
+        endTime,
+        planOpenChattingLink
+    ).combineAll()
+        .map { values ->
+            val currentPage = values[0] as Int
+            val planTitle = values[1] as String
+            val planDate = values[2] as String
+            val startTime = values[3] as String
+            val endTime = values[4] as String
+            val planOpenChattingLink = values[5] as String
+
             (currentPage == PlanType.TITLE.position - 1 && planTitle.isNotBlank()) ||
-                currentPage == 1 ||
+                (currentPage == 1 && planDate.isNotBlank() && startTime.isNotBlank() && endTime.isNotBlank()) ||
                 (currentPage == 2 && planOpenChattingLink.isNotBlank())
-        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), false)
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), false)
 
     fun setCurrentPage(position: Int) {
         _currentPage.value = position
@@ -38,6 +60,14 @@ class PlanViewModel : ViewModel() {
 
     fun setPlanDate(planDate: String) {
         _planDate.value = planDate
+    }
+
+    fun setStartTime(time: String) {
+        _startTime.value = time
+    }
+
+    fun setEndTime(time: String) {
+        _endTime.value = time
     }
 
     fun setSelectedTimeType(timeType: String) {

--- a/app/src/main/java/org/sopt/pingle/util/CombineAll.kt
+++ b/app/src/main/java/org/sopt/pingle/util/CombineAll.kt
@@ -1,0 +1,14 @@
+package org.sopt.pingle.util
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combineTransform
+import kotlinx.coroutines.flow.flowOf
+
+inline fun <reified T> List<Flow<T>>.combineAll(): Flow<List<T>> {
+    return when (size) {
+        0 -> flowOf(emptyList())
+        else -> combineTransform(this) { flows ->
+            emit(flows.toList())
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,12 +53,13 @@
     <string name="plan_et_title">한줄 소개</string>
     <string name="plan_title">개최할 핑글을\n소개해주세요!</string>
     <string name="plan_et_hint">ex. 강남역에서 각잡고 공부할 사람?</string>
+    <string name="plan_future_date_snackber">미래 날짜를 선택해주세요</string>
+    <string name="plan_open_chatting_hint">링크를 입력해주세요</string>
+    <string name="plan_open_chatting_title">채팅방 링크</string>
 
     <!-- map -->
     <string name="map_participate">참여하기</string>
 
     <!-- map modal -->
     <string name="map_modal_description">이 핑글에 참여할까요?</string>
-    <string name="plan_open_chatting_hint">링크를 입력해주세요</string>
-    <string name="plan_open_chatting_title">채팅방 링크</string>
 </resources>


### PR DESCRIPTION
## Related issue 🛠
- closed #50 

## Work Description ✏️
- 미래 날짜를 띄어주세요 에러 스낵바 띄우기
- 오전/오후 시간 -> 24H로 수정해서 뷰에 띄우기
- 서버에게 보내줄 Date + time LocalDate 형태 스트링으로 가공
- combineAll 확장함수 구현
- 버튼 활성/비활성 로직 수정

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅
- [ ] 시작 시간 > 종료시간일때 스낵바 띄우기

## To Reviewers 📢
플로우의 컴바인이 5개 이상의 flow를 결합할 수 없는 문제가 있어 여러 flow를 동시에 컴바인할 수 있는 combineAll 확장함수를 구현했습니다.
