### PR TITLE
[feat] 메인 지도 뷰 전체적인 연결

### DIFF
--- a/app/src/main/java/org/sopt/pingle/presentation/mapper/CategoryTypeMapper.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/mapper/CategoryTypeMapper.kt
@@ -1,0 +1,12 @@
+package org.sopt.pingle.presentation.mapper
+
+import org.sopt.pingle.presentation.type.CategoryType
+import org.sopt.pingle.presentation.ui.main.home.map.MapFragment
+
+fun CategoryType.toMarkerIcon(isSelected: Boolean) =
+    when (this) {
+        CategoryType.PLAY -> if (isSelected) MapFragment.OVERLAY_IMAGE_PLAY_BIG else MapFragment.OVERLAY_IMAGE_PLAY_SMALL
+        CategoryType.STUDY -> if (isSelected) MapFragment.OVERLAY_IMAGE_STUDY_BIG else MapFragment.OVERLAY_IMAGE_STUDY_SMALL
+        CategoryType.MULTI -> if (isSelected) MapFragment.OVERLAY_IMAGE_MULTI_BIG else MapFragment.OVERLAY_IMAGE_MULTI_SMALL
+        CategoryType.OTHERS -> if (isSelected) MapFragment.OVERLAY_IMAGE_OTHER_BIG else MapFragment.OVERLAY_IMAGE_OTHER_SMALL
+    }

--- a/app/src/main/java/org/sopt/pingle/presentation/mapper/PinMapper.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/mapper/PinMapper.kt
@@ -8,21 +8,23 @@ import org.sopt.pingle.presentation.model.MarkerModel
 import org.sopt.pingle.presentation.type.CategoryType
 
 fun PinEntity.toMarkerModel(): MarkerModel {
-    val markerModel = MarkerModel(Marker().apply {
-        position = LatLng(y, x)
-        isHideCollidedMarkers = true
-        icon = CategoryType.fromString(category).toMarkerIcon(false)
-    })
+    val markerModel = MarkerModel(
+        Marker().apply {
+            position = LatLng(y, x)
+            isHideCollidedMarkers = true
+            icon = CategoryType.fromString(category).toMarkerIcon(false)
+        }
+    )
 
-    markerModel.isSelected.addOnPropertyChangedCallback(object :
-        Observable.OnPropertyChangedCallback() {
-        override fun onPropertyChanged(sender: Observable?, propertyId: Int) {
-
-            with(markerModel.marker) {
-                icon = CategoryType.fromString(category).toMarkerIcon(markerModel.isSelected.get())
+    markerModel.isSelected.addOnPropertyChangedCallback(
+        object :
+            Observable.OnPropertyChangedCallback() {
+            override fun onPropertyChanged(sender: Observable?, propertyId: Int) {
+                with(markerModel.marker) {
+                    icon = CategoryType.fromString(category).toMarkerIcon(markerModel.isSelected.get())
+                }
             }
         }
-    }
     )
 
     return markerModel

--- a/app/src/main/java/org/sopt/pingle/presentation/mapper/PinMapper.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/mapper/PinMapper.kt
@@ -1,21 +1,29 @@
 package org.sopt.pingle.presentation.mapper
 
+import androidx.databinding.Observable
 import com.naver.maps.geometry.LatLng
 import com.naver.maps.map.overlay.Marker
-import com.naver.maps.map.overlay.OverlayImage
-import org.sopt.pingle.R
 import org.sopt.pingle.domain.model.PinEntity
+import org.sopt.pingle.presentation.model.MarkerModel
 import org.sopt.pingle.presentation.type.CategoryType
 
-fun PinEntity.toMarker(): Marker = Marker().apply {
-    position = LatLng(y, x)
-    isHideCollidedMarkers = true
-    icon = OverlayImage.fromResource(
-        when (category) {
-            CategoryType.PLAY.toString() -> R.drawable.ic_map_marker_play_small
-            CategoryType.STUDY.toString() -> R.drawable.ic_map_marker_study_small
-            CategoryType.MULTI.toString() -> R.drawable.ic_map_marker_multi_small
-            else -> R.drawable.ic_map_marker_other_small
+fun PinEntity.toMarkerModel(): MarkerModel {
+    val markerModel = MarkerModel(Marker().apply {
+        position = LatLng(y, x)
+        isHideCollidedMarkers = true
+        icon = CategoryType.fromString(category).toMarkerIcon(false)
+    })
+
+    markerModel.isSelected.addOnPropertyChangedCallback(object :
+        Observable.OnPropertyChangedCallback() {
+        override fun onPropertyChanged(sender: Observable?, propertyId: Int) {
+
+            with(markerModel.marker) {
+                icon = CategoryType.fromString(category).toMarkerIcon(markerModel.isSelected.get())
+            }
         }
+    }
     )
+
+    return markerModel
 }

--- a/app/src/main/java/org/sopt/pingle/presentation/model/MarkerModel.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/model/MarkerModel.kt
@@ -1,0 +1,9 @@
+package org.sopt.pingle.presentation.model
+
+import androidx.databinding.ObservableBoolean
+import com.naver.maps.map.overlay.Marker
+
+data class MarkerModel(
+    val marker: Marker,
+    var isSelected: ObservableBoolean = ObservableBoolean(false)
+)

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/map/MapFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/map/MapFragment.kt
@@ -105,7 +105,7 @@ class MapFragment : BindingFragment<FragmentMapBinding>(R.layout.fragment_map), 
     private fun addListeners() {
         binding.fabMapHere.setOnClickListener {
             if (::locationSource.isInitialized) {
-                locationSource.lastLocation?.let { location -> moveMapCamera(location) }
+                locationSource.lastLocation?.let { location -> moveMapCamera(LatLng(location.latitude, location.latitude)) }
             }
         }
 
@@ -123,15 +123,16 @@ class MapFragment : BindingFragment<FragmentMapBinding>(R.layout.fragment_map), 
             showToast(it?.name ?: "null")
         }.launchIn(lifecycleScope)
 
-        mapViewModel.selectedMarkerPosition.flowWithLifecycle(lifecycle).onEach { selectedMarkerPosition ->
-            (selectedMarkerPosition == MapViewModel.DEFAULT_SELECTED_MARKER_POSITION).run {
-                with(binding) {
-                    fabMapHere.visibility = if (this@run) View.VISIBLE else View.INVISIBLE
-                    fabMapList.visibility = if (this@run) View.VISIBLE else View.INVISIBLE
-                    cardMap.visibility = if (this@run) View.INVISIBLE else View.VISIBLE
+        mapViewModel.selectedMarkerPosition.flowWithLifecycle(lifecycle)
+            .onEach { selectedMarkerPosition ->
+                (selectedMarkerPosition == MapViewModel.DEFAULT_SELECTED_MARKER_POSITION).run {
+                    with(binding) {
+                        fabMapHere.visibility = if (this@run) View.VISIBLE else View.INVISIBLE
+                        fabMapList.visibility = if (this@run) View.VISIBLE else View.INVISIBLE
+                        cardMap.visibility = if (this@run) View.INVISIBLE else View.VISIBLE
+                    }
                 }
-            }
-        }.launchIn(lifecycleScope)
+            }.launchIn(lifecycleScope)
     }
 
     private fun setLocationTrackingMode() {
@@ -160,7 +161,7 @@ class MapFragment : BindingFragment<FragmentMapBinding>(R.layout.fragment_map), 
                 }
             }
 
-            moveMapCamera(location)
+            moveMapCamera(LatLng(location.latitude, location.longitude))
         }
     }
 
@@ -178,15 +179,10 @@ class MapFragment : BindingFragment<FragmentMapBinding>(R.layout.fragment_map), 
         locationPermissionRequest.launch(LOCATION_PERMISSIONS)
     }
 
-    private fun moveMapCamera(location: Location) {
+    private fun moveMapCamera(latLng: LatLng) {
         if (::naverMap.isInitialized) {
             naverMap.moveCamera(
-                CameraUpdate.scrollTo(
-                    LatLng(
-                        location.latitude,
-                        location.longitude
-                    )
-                ).animate(CameraAnimation.Linear)
+                CameraUpdate.scrollTo(latLng).animate(CameraAnimation.Linear)
             )
         }
     }
@@ -200,6 +196,7 @@ class MapFragment : BindingFragment<FragmentMapBinding>(R.layout.fragment_map), 
                         handleMarkerClick(index)
                         // TODO 마커 상세 정보 받아오는 로직 추가
                         binding.cardMap.initLayout(dummyPingle)
+                        moveMapCamera(position)
                     }
                     return@setOnClickListener true
                 }

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/map/MapFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/map/MapFragment.kt
@@ -152,11 +152,11 @@ class MapFragment : BindingFragment<FragmentMapBinding>(R.layout.fragment_map), 
 
     private fun setLocationTrackingMode() {
         if (LOCATION_PERMISSIONS.any { permission ->
-                ContextCompat.checkSelfPermission(
+            ContextCompat.checkSelfPermission(
                     requireContext(),
                     permission
                 ) == PackageManager.PERMISSION_GRANTED
-            }
+        }
         ) {
             locationSource = FusedLocationSource(this, LOCATION_PERMISSION_REQUEST_CODE)
 
@@ -173,11 +173,9 @@ class MapFragment : BindingFragment<FragmentMapBinding>(R.layout.fragment_map), 
             locationPermissionRequest.launch(LOCATION_PERMISSIONS)
         }
 
-
         LocationServices.getFusedLocationProviderClient(requireContext()).lastLocation.addOnSuccessListener { location ->
             moveMapCamera(LatLng(location.latitude, location.longitude))
         }
-
     }
 
     private fun moveMapCamera(latLng: LatLng) {

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/map/MapViewModel.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/map/MapViewModel.kt
@@ -1,10 +1,13 @@
 package org.sopt.pingle.presentation.ui.main.home.map
 
 import androidx.lifecycle.ViewModel
+import com.naver.maps.geometry.LatLng
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import org.sopt.pingle.domain.model.PinEntity
 import org.sopt.pingle.domain.model.PingleEntity
+import org.sopt.pingle.presentation.mapper.toMarkerModel
+import org.sopt.pingle.presentation.model.MarkerModel
 import org.sopt.pingle.presentation.type.CategoryType
 
 class MapViewModel() : ViewModel() {
@@ -54,11 +57,49 @@ class MapViewModel() : ViewModel() {
         chatLink = "https://github.com/TeamPINGLE/PINGLE-ANDROID"
     )
 
+    private val _cameraPoint = MutableStateFlow<LatLng>(LatLng(DEFAULT_LAT, DEFAULT_LNG))
+    val cameraPoint get() = _cameraPoint.asStateFlow()
+
     private val _category = MutableStateFlow<CategoryType?>(null)
     val category get() = _category.asStateFlow()
 
+    private var _markerList = MutableStateFlow<List<MarkerModel>>(emptyList())
+    val markerList get() = _markerList.asStateFlow()
+
+    private var _selectedMarkerPosition = MutableStateFlow(DEFAULT_SELECTED_MARKER_POSITION)
+    val selectedMarkerPosition = _selectedMarkerPosition.asStateFlow()
+
+    init {
+        setMarkerList()
+    }
+
     fun setCategory(category: CategoryType?) {
         _category.value = category
+    }
+
+    fun setMarkerList() {
+        _markerList.value = dummyPinList.map { pinEntity ->
+            pinEntity.toMarkerModel()
+        }
+    }
+
+    fun handleMarkerClick(position: Int) {
+        setMarkerIsSelected(position)
+        if (_selectedMarkerPosition.value != DEFAULT_SELECTED_MARKER_POSITION) setMarkerIsSelected(
+            _selectedMarkerPosition.value
+        )
+        _selectedMarkerPosition.value = position
+    }
+
+    fun clearSelectedMarkerPosition() {
+        if (_selectedMarkerPosition.value != DEFAULT_SELECTED_MARKER_POSITION) {
+            setMarkerIsSelected(_selectedMarkerPosition.value)
+            _selectedMarkerPosition.value = DEFAULT_SELECTED_MARKER_POSITION
+        }
+    }
+
+    private fun setMarkerIsSelected(position: Int) {
+        markerList.value[position].isSelected.set(!markerList.value[position].isSelected.get())
     }
 
     fun cancelPingle() {

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/map/MapViewModel.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/map/MapViewModel.kt
@@ -1,7 +1,6 @@
 package org.sopt.pingle.presentation.ui.main.home.map
 
 import androidx.lifecycle.ViewModel
-import com.naver.maps.geometry.LatLng
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import org.sopt.pingle.domain.model.PinEntity
@@ -82,9 +81,11 @@ class MapViewModel() : ViewModel() {
 
     fun handleMarkerClick(position: Int) {
         setMarkerIsSelected(position)
-        if (_selectedMarkerPosition.value != DEFAULT_SELECTED_MARKER_POSITION) setMarkerIsSelected(
-            _selectedMarkerPosition.value
-        )
+        if (_selectedMarkerPosition.value != DEFAULT_SELECTED_MARKER_POSITION) {
+            setMarkerIsSelected(
+                _selectedMarkerPosition.value
+            )
+        }
         _selectedMarkerPosition.value = position
     }
 

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/map/MapViewModel.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/map/MapViewModel.kt
@@ -57,9 +57,6 @@ class MapViewModel() : ViewModel() {
         chatLink = "https://github.com/TeamPINGLE/PINGLE-ANDROID"
     )
 
-    private val _cameraPoint = MutableStateFlow<LatLng>(LatLng(DEFAULT_LAT, DEFAULT_LNG))
-    val cameraPoint get() = _cameraPoint.asStateFlow()
-
     private val _category = MutableStateFlow<CategoryType?>(null)
     val category get() = _category.asStateFlow()
 
@@ -134,5 +131,9 @@ class MapViewModel() : ViewModel() {
             isParticipating = true,
             chatLink = "https://github.com/TeamPINGLE/PINGLE-ANDROID"
         )
+    }
+
+    companion object {
+        const val DEFAULT_SELECTED_MARKER_POSITION = -1
     }
 }

--- a/app/src/main/res/drawable/ic_map_marker_multi_big.xml
+++ b/app/src/main/res/drawable/ic_map_marker_multi_big.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="63dp"
+    android:height="63dp"
+    android:viewportWidth="63"
+    android:viewportHeight="63">
+    <path
+        android:fillColor="#F2FF5E"
+        android:pathData="M31.5,0L31.5,0A31.5,31.5 0,0 1,63 31.5L63,31.5A31.5,31.5 0,0 1,31.5 63L31.5,63A31.5,31.5 0,0 1,0 31.5L0,31.5A31.5,31.5 0,0 1,31.5 0z" />
+</vector>

--- a/app/src/main/res/drawable/ic_map_marker_other_big.xml
+++ b/app/src/main/res/drawable/ic_map_marker_other_big.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="63dp"
+    android:height="63dp"
+    android:viewportWidth="63"
+    android:viewportHeight="63">
+    <path
+        android:fillColor="#EDF0F4"
+        android:pathData="M31.5,0L31.5,0A31.5,31.5 0,0 1,63 31.5L63,31.5A31.5,31.5 0,0 1,31.5 63L31.5,63A31.5,31.5 0,0 1,0 31.5L0,31.5A31.5,31.5 0,0 1,31.5 0z" />
+</vector>

--- a/app/src/main/res/drawable/ic_map_marker_play_big.xml
+++ b/app/src/main/res/drawable/ic_map_marker_play_big.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="63dp"
+    android:height="63dp"
+    android:viewportWidth="63"
+    android:viewportHeight="63">
+    <path
+        android:fillColor="#B7FF1D"
+        android:pathData="M31.5,0L31.5,0A31.5,31.5 0,0 1,63 31.5L63,31.5A31.5,31.5 0,0 1,31.5 63L31.5,63A31.5,31.5 0,0 1,0 31.5L0,31.5A31.5,31.5 0,0 1,31.5 0z" />
+</vector>

--- a/app/src/main/res/drawable/ic_map_marker_study_big.xml
+++ b/app/src/main/res/drawable/ic_map_marker_study_big.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="63dp"
+    android:height="63dp"
+    android:viewportWidth="63"
+    android:viewportHeight="63">
+    <path
+        android:fillColor="#FF9254"
+        android:pathData="M31.5,0L31.5,0A31.5,31.5 0,0 1,63 31.5L63,31.5A31.5,31.5 0,0 1,31.5 63L31.5,63A31.5,31.5 0,0 1,0 31.5L0,31.5A31.5,31.5 0,0 1,31.5 0z" />
+</vector>


### PR DESCRIPTION
## Related issue 🛠
- closed #41 

## Work Description ✏️
- 메인 지도 뷰의 전체적인 연결을 진행하였습니다.
- 바텀 네비를 통해 다른 프래그먼트로 전환하였다 다시 메인 지도 프래그먼트로 돌아올 때 실시간 위치가 뷰에 반영되지 않는 문제를 해결하였습니다.

## Screenshot 📸
https://github.com/TeamPINGLE/PINGLE-ANDROID/assets/103172971/7de7363d-0b95-47d7-9452-27542f43c7f2

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
- 안핑이들아 내가 해냈다 ㅠ.ㅜ
- 카드 내 핑글 정보는 서버에서 받아와야 하는 부분이기 때문에 일단 더미로 박아두었습니당!!!
- 근데,, 실시간 위치 받아오는데 시간이 좀 걸려서 빨간 점 뜨는데까지 딜레이가 생기네요,, 하암 ~ 일단 다른 뷰 끝내고 수정하겠습니다.