### PR TITLE
[feat] 핑글 개최 프로세스 - 모집인원 입력 뷰 구현

### DIFF
--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/plan/PlanActivity.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/plan/PlanActivity.kt
@@ -29,6 +29,7 @@ class PlanActivity : BindingActivity<ActivityPlanBinding>(R.layout.activity_plan
         fragmentList.apply {
             add(PlanTitleFragment())
             add(PlanDateTimeFragment())
+            add(PlanRecruitmentFragment())
             add(PlanOpenChattingFragment())
         }
 
@@ -37,12 +38,12 @@ class PlanActivity : BindingActivity<ActivityPlanBinding>(R.layout.activity_plan
             this.adapter = adapter
             isUserInputEnabled = false
             registerOnPageChangeCallback(object :
-                    ViewPager2.OnPageChangeCallback() {
-                    override fun onPageSelected(position: Int) {
-                        super.onPageSelected(position)
-                        planViewModel.setCurrentPage(position)
-                    }
-                })
+                ViewPager2.OnPageChangeCallback() {
+                override fun onPageSelected(position: Int) {
+                    super.onPageSelected(position)
+                    planViewModel.setCurrentPage(position)
+                }
+            })
         }
     }
 

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/plan/PlanRecruitmentFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/plan/PlanRecruitmentFragment.kt
@@ -1,6 +1,7 @@
 package org.sopt.pingle.presentation.ui.main.plan
 
 import android.os.Bundle
+import android.view.KeyEvent
 import android.view.View
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.flowWithLifecycle
@@ -28,18 +29,29 @@ class PlanRecruitmentFragment :
     }
 
     private fun addListeners() {
-        binding.root.setOnClickListener { requireActivity().hideKeyboard(it) }
+        with(binding) {
+            root.setOnClickListener {
+                requireActivity().hideKeyboard(it)
+                viewModel.setSelectedRecruitment(etPlanRecruitmentInputNumber.text.toString())
+            }
 
-        binding.btnPlanRecruitmentPlus.setOnClickListener {
-            var i = viewModel.selectedRecruitment.value?.toInt()
-            i = i!! + 1
-            viewModel.incRecruitmentNum()
-        }
+            etPlanRecruitmentInputNumber.setOnKeyListener(
+                View.OnKeyListener { _, keyCode, event ->
+                    if (keyCode == KeyEvent.KEYCODE_ENTER && event.action == KeyEvent.ACTION_UP) {
+                        viewModel.setSelectedRecruitment(etPlanRecruitmentInputNumber.text.toString())
+                        return@OnKeyListener true
+                    }
+                    false
+                },
+            )
 
-        binding.btnPlanRecruitmentMinus.setOnClickListener {
-            var i = viewModel.selectedRecruitment.value?.toInt()
-            i = i!! - 1
-            viewModel.decRecruitmentNum()
+            btnPlanRecruitmentPlus.setOnClickListener {
+                viewModel.incRecruitmentNum()
+            }
+
+            btnPlanRecruitmentMinus.setOnClickListener {
+                viewModel.decRecruitmentNum()
+            }
         }
     }
 
@@ -51,7 +63,7 @@ class PlanRecruitmentFragment :
                     CustomSnackbar.makeSnackbar(
                         binding.layoutPlanRecruitment,
                         getString(R.string.plan_recruitment_snackbar),
-                        126
+                        126,
                     )
                 }
 

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/plan/PlanRecruitmentFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/plan/PlanRecruitmentFragment.kt
@@ -16,11 +16,11 @@ import org.sopt.pingle.util.context.hideKeyboard
 class PlanRecruitmentFragment :
     BindingFragment<FragmentPlanRecruitmentBinding>(R.layout.fragment_plan_recruitment) {
 
-    private val planViewModel: PlanViewModel by activityViewModels()
+    private val viewModel: PlanViewModel by activityViewModels()
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        binding.planViewModel = planViewModel
+        binding.planViewModel = viewModel
         binding.lifecycleOwner = this
 
         addListeners()
@@ -31,25 +31,23 @@ class PlanRecruitmentFragment :
         binding.root.setOnClickListener { requireActivity().hideKeyboard(it) }
 
         binding.btnPlanRecruitmentPlus.setOnClickListener {
-            var i = planViewModel.selectedRecruitment.value?.toInt()
+            var i = viewModel.selectedRecruitment.value?.toInt()
             i = i!! + 1
-            planViewModel.selectedRecruitment.value = i.toString()
+            viewModel.incRecruitmentNum()
         }
 
         binding.btnPlanRecruitmentMinus.setOnClickListener {
-            var i = planViewModel.selectedRecruitment.value?.toInt()
+            var i = viewModel.selectedRecruitment.value?.toInt()
             i = i!! - 1
-            planViewModel.selectedRecruitment.value = i.toString()
+            viewModel.decRecruitmentNum()
         }
     }
 
     private fun collectData() {
-        planViewModel.selectedRecruitment.flowWithLifecycle(lifecycle).onEach {
+        viewModel.selectedRecruitment.flowWithLifecycle(lifecycle).onEach {
             when (it.toString()) {
                 "99" -> {
-                    binding.btnPlanRecruitmentPlus.apply {
-                        isEnabled = false
-                    }
+                    binding.btnPlanRecruitmentPlus.isEnabled = false
                     CustomSnackbar.makeSnackbar(
                         binding.layoutPlanRecruitment,
                         getString(R.string.plan_recruitment_snackbar),

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/plan/PlanRecruitmentFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/plan/PlanRecruitmentFragment.kt
@@ -1,0 +1,24 @@
+package org.sopt.pingle.presentation.ui.main.plan
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import org.sopt.pingle.R
+import org.sopt.pingle.databinding.FragmentPlanRecruitmentBinding
+import org.sopt.pingle.util.base.BindingFragment
+
+class PlanRecruitmentFragment :
+    BindingFragment<FragmentPlanRecruitmentBinding>(R.layout.fragment_plan_recruitment) {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        return super.onCreateView(inflater, container, savedInstanceState)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+    }
+}

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/plan/PlanRecruitmentFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/plan/PlanRecruitmentFragment.kt
@@ -42,7 +42,7 @@ class PlanRecruitmentFragment :
                         return@OnKeyListener true
                     }
                     false
-                },
+                }
             )
 
             btnPlanRecruitmentPlus.setOnClickListener {
@@ -63,7 +63,7 @@ class PlanRecruitmentFragment :
                     CustomSnackbar.makeSnackbar(
                         binding.layoutPlanRecruitment,
                         getString(R.string.plan_recruitment_snackbar),
-                        126,
+                        126
                     )
                 }
 

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/plan/PlanRecruitmentFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/plan/PlanRecruitmentFragment.kt
@@ -1,24 +1,71 @@
 package org.sopt.pingle.presentation.ui.main.plan
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import org.sopt.pingle.R
 import org.sopt.pingle.databinding.FragmentPlanRecruitmentBinding
 import org.sopt.pingle.util.base.BindingFragment
+import org.sopt.pingle.util.component.CustomSnackbar
+import org.sopt.pingle.util.context.hideKeyboard
 
 class PlanRecruitmentFragment :
     BindingFragment<FragmentPlanRecruitmentBinding>(R.layout.fragment_plan_recruitment) {
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?,
-    ): View {
-        return super.onCreateView(inflater, container, savedInstanceState)
+
+    private val planViewModel: PlanViewModel by activityViewModels()
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.planViewModel = planViewModel
+        binding.lifecycleOwner = this
+
+        addListeners()
+        collectData()
     }
 
-    override fun onDestroyView() {
-        super.onDestroyView()
+    private fun addListeners() {
+        binding.root.setOnClickListener { requireActivity().hideKeyboard(it) }
+
+        binding.btnPlanRecruitmentPlus.setOnClickListener {
+            var i = planViewModel.selectedRecruitment.value?.toInt()
+            i = i!! + 1
+            planViewModel.selectedRecruitment.value = i.toString()
+        }
+
+        binding.btnPlanRecruitmentMinus.setOnClickListener {
+            var i = planViewModel.selectedRecruitment.value?.toInt()
+            i = i!! - 1
+            planViewModel.selectedRecruitment.value = i.toString()
+        }
+    }
+
+    private fun collectData() {
+        planViewModel.selectedRecruitment.flowWithLifecycle(lifecycle).onEach {
+            when (it.toString()) {
+                "99" -> {
+                    binding.btnPlanRecruitmentPlus.apply {
+                        isEnabled = false
+                    }
+                    CustomSnackbar.makeSnackbar(
+                        binding.layoutPlanRecruitment,
+                        getString(R.string.plan_recruitment_snackbar),
+                        126
+                    )
+                }
+
+                "1" -> {
+                    binding.btnPlanRecruitmentMinus.isEnabled = false
+                }
+
+                else -> {
+                    binding.btnPlanRecruitmentPlus.isEnabled = true
+                    binding.btnPlanRecruitmentMinus.isEnabled = true
+                }
+            }
+        }.launchIn(lifecycleScope)
     }
 }

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/plan/PlanViewModel.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/plan/PlanViewModel.kt
@@ -26,7 +26,7 @@ class PlanViewModel : ViewModel() {
         combine(
             currentPage,
             planTitle,
-            planOpenChattingLink
+            planOpenChattingLink,
         ) { currentPage, planTitle, planOpenChattingLink ->
             (currentPage == PlanType.TITLE.position - 1 && planTitle.isNotBlank()) ||
                 currentPage == 1 ||
@@ -50,7 +50,24 @@ class PlanViewModel : ViewModel() {
     private val _selectedCategory = MutableStateFlow<CategoryType?>(null)
     val selectedCategory get() = _selectedCategory.asStateFlow()
 
-    val selectedRecruitment = MutableStateFlow<String?>("1")
+    private val _selectedRecruitment = MutableStateFlow<String?>("1")
+    val selectedRecruitment get() = _selectedRecruitment.asStateFlow()
+
+    fun incRecruitmentNum() {
+        var i = selectedRecruitment.value?.toInt()
+        i = i!! + 1
+        setSelectedRecruitment(i.toString())
+    }
+
+    fun decRecruitmentNum() {
+        var i = selectedRecruitment.value?.toInt()
+        i = i!! - 1
+        setSelectedRecruitment(i.toString())
+    }
+
+    fun setSelectedRecruitment(recruitment: String) {
+        _selectedRecruitment.value = recruitment
+    }
 
     fun setSelectedCategory(categoryType: CategoryType) {
         _selectedCategory.value = categoryType

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/plan/PlanViewModel.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/plan/PlanViewModel.kt
@@ -33,6 +33,8 @@ class PlanViewModel : ViewModel() {
                 (currentPage == 2 && planOpenChattingLink.isNotBlank())
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), false)
 
+    // val isPlanBtnEnabled = MutableStateFlow(true)
+
     private val _location = MutableStateFlow<String?>(null)
     val location get() = _location.asStateFlow()
 
@@ -45,9 +47,10 @@ class PlanViewModel : ViewModel() {
     private val _address = MutableStateFlow<String?>(null)
     val address get() = _address.asStateFlow()
 
-    // TODO 뷰 연결 시 버튼 활성/비활성화 로직 isPlanBtnEnabled에 추가
     private val _selectedCategory = MutableStateFlow<CategoryType?>(null)
     val selectedCategory get() = _selectedCategory.asStateFlow()
+
+    val selectedRecruitment = MutableStateFlow<String?>("1")
 
     fun setSelectedCategory(categoryType: CategoryType) {
         _selectedCategory.value = categoryType
@@ -71,6 +74,7 @@ class PlanViewModel : ViewModel() {
         _y.value = locationY
         _address.value = address
     }
+
     companion object {
         const val FIRST_PAGE_POSITION = 0
     }

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/plan/PlanViewModel.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/plan/PlanViewModel.kt
@@ -26,7 +26,7 @@ class PlanViewModel : ViewModel() {
         combine(
             currentPage,
             planTitle,
-            planOpenChattingLink,
+            planOpenChattingLink
         ) { currentPage, planTitle, planOpenChattingLink ->
             (currentPage == PlanType.TITLE.position - 1 && planTitle.isNotBlank()) ||
                 currentPage == 1 ||

--- a/app/src/main/res/color/selector_plan_recruitment_btn.xml
+++ b/app/src/main/res/color/selector_plan_recruitment_btn.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/g_08" android:state_enabled="false"/>
+    <item android:color="@color/g_02" android:state_enabled="true"/>
+</selector>

--- a/app/src/main/res/color/selector_plan_recruitment_btn_text.xml
+++ b/app/src/main/res/color/selector_plan_recruitment_btn_text.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/g_10" android:state_enabled="false" />
+    <item android:color="@color/black" android:state_enabled="true" />
+</selector>

--- a/app/src/main/res/layout/fragment_plan_recruitment.xml
+++ b/app/src/main/res/layout/fragment_plan_recruitment.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data></data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".presentation.ui.main.plan.PlanRecruitmentFragment">
+
+        <TextView
+            android:id="@+id/tv_plan_recruitment_title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/spacing8"
+            android:text="@string/plan_recruitment_title"
+            android:textAppearance="@style/TextAppearance.Pingle.Title.Semi.24"
+            android:textColor="@color/white"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_plan_recruitment_description"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="@dimen/spacing12"
+            android:text="@string/plan_recruitment_description"
+            android:textAppearance="@style/TextAppearance.Pingle.Body.Med.14"
+            android:textColor="@color/g_05"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_plan_recruitment_title" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/layout_plan_recruitment_input"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/spacing20"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_plan_recruitment_description">
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/btn_plan_recruitment_minus"
+                android:layout_width="wrap_content"
+                android:layout_height="0dp"
+                android:layout_marginTop="47dp"
+                android:layout_marginEnd="@dimen/spacing20"
+                android:background="@drawable/shape_border_radius_10"
+                android:backgroundTint="@color/g_08"
+                android:minWidth="0dp"
+                android:paddingHorizontal="@dimen/spacing18"
+                android:paddingVertical="@dimen/spacing8"
+                android:text="@string/plan_recruitment_minus"
+                android:textAppearance="@style/TextAppearance.Pingle.Title.Semi.24"
+                android:textColor="@color/g_09"
+                app:layout_constraintEnd_toStartOf="@id/et_plan_recruitment_input_number"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <EditText
+                android:id="@+id/et_plan_recruitment_input_number"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/spacing16"
+                android:background="@drawable/shape_border_radius_12"
+                android:backgroundTint="@color/g_10"
+                android:inputType="number"
+                android:paddingHorizontal="34dp"
+                android:paddingVertical="@dimen/spacing28"
+                android:text="@string/plan_recruitment_default"
+                android:textAppearance="@style/TextAppearance.Pingle.Title.Semi.32"
+                android:textColor="@color/white"
+                android:textCursorDrawable="@color/pingle_green"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/btn_plan_recruitment_plus"
+                android:layout_width="wrap_content"
+                android:layout_height="0dp"
+                android:layout_marginStart="@dimen/spacing20"
+                android:layout_marginTop="47dp"
+                android:background="@drawable/shape_border_radius_10"
+                android:backgroundTint="@color/g_02"
+                android:minWidth="0dp"
+                android:paddingHorizontal="@dimen/spacing18"
+                android:paddingVertical="@dimen/spacing8"
+                android:text="@string/plan_recruitment_plus"
+                android:textAppearance="@style/TextAppearance.Pingle.Title.Semi.24"
+                android:textColor="@color/black"
+                app:layout_constraintStart_toEndOf="@id/et_plan_recruitment_input_number"
+                app:layout_constraintTop_toTopOf="parent" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_plan_recruitment.xml
+++ b/app/src/main/res/layout/fragment_plan_recruitment.xml
@@ -3,9 +3,14 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <data></data>
+    <data>
+        <variable
+            name="planViewModel"
+            type="org.sopt.pingle.presentation.ui.main.plan.PlanViewModel" />
+    </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_plan_recruitment"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:context=".presentation.ui.main.plan.PlanRecruitmentFragment">
@@ -34,7 +39,6 @@
             app:layout_constraintTop_toBottomOf="@id/tv_plan_recruitment_title" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/layout_plan_recruitment_input"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing20"
@@ -46,30 +50,32 @@
                 android:id="@+id/btn_plan_recruitment_minus"
                 android:layout_width="wrap_content"
                 android:layout_height="0dp"
+                android:enabled="false"
                 android:layout_marginTop="47dp"
                 android:layout_marginEnd="@dimen/spacing20"
                 android:background="@drawable/shape_border_radius_10"
-                android:backgroundTint="@color/g_08"
+                android:backgroundTint="@color/selector_plan_recruitment_btn"
                 android:minWidth="0dp"
-                android:paddingHorizontal="@dimen/spacing18"
+                android:paddingHorizontal="@dimen/spacing16"
                 android:paddingVertical="@dimen/spacing8"
                 android:text="@string/plan_recruitment_minus"
                 android:textAppearance="@style/TextAppearance.Pingle.Title.Semi.24"
-                android:textColor="@color/g_09"
+                android:textColor="@color/selector_plan_recruitment_btn_text"
                 app:layout_constraintEnd_toStartOf="@id/et_plan_recruitment_input_number"
                 app:layout_constraintTop_toTopOf="parent" />
 
             <EditText
                 android:id="@+id/et_plan_recruitment_input_number"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+                android:layout_width="81dp"
+                android:layout_height="0dp"
                 android:layout_marginTop="@dimen/spacing16"
                 android:background="@drawable/shape_border_radius_12"
                 android:backgroundTint="@color/g_10"
                 android:inputType="number"
-                android:paddingHorizontal="34dp"
+                android:gravity="center"
                 android:paddingVertical="@dimen/spacing28"
-                android:text="@string/plan_recruitment_default"
+                android:maxLength="2"
+                android:text="@={planViewModel.selectedRecruitment}"
                 android:textAppearance="@style/TextAppearance.Pingle.Title.Semi.32"
                 android:textColor="@color/white"
                 android:textCursorDrawable="@color/pingle_green"
@@ -84,13 +90,14 @@
                 android:layout_marginStart="@dimen/spacing20"
                 android:layout_marginTop="47dp"
                 android:background="@drawable/shape_border_radius_10"
-                android:backgroundTint="@color/g_02"
+                android:backgroundTint="@color/selector_plan_recruitment_btn"
                 android:minWidth="0dp"
-                android:paddingHorizontal="@dimen/spacing18"
+                android:enabled="true"
+                android:paddingHorizontal="@dimen/spacing16"
                 android:paddingVertical="@dimen/spacing8"
                 android:text="@string/plan_recruitment_plus"
                 android:textAppearance="@style/TextAppearance.Pingle.Title.Semi.24"
-                android:textColor="@color/black"
+                android:textColor="@color/selector_plan_recruitment_btn_text"
                 app:layout_constraintStart_toEndOf="@id/et_plan_recruitment_input_number"
                 app:layout_constraintTop_toTopOf="parent" />
         </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_plan_recruitment.xml
+++ b/app/src/main/res/layout/fragment_plan_recruitment.xml
@@ -75,7 +75,7 @@
                 android:gravity="center"
                 android:paddingVertical="@dimen/spacing28"
                 android:maxLength="2"
-                android:text="@={planViewModel.selectedRecruitment}"
+                android:text="@{planViewModel.selectedRecruitment}"
                 android:textAppearance="@style/TextAppearance.Pingle.Title.Semi.32"
                 android:textColor="@color/white"
                 android:textCursorDrawable="@color/pingle_green"

--- a/app/src/main/res/layout/item_plan_location.xml
+++ b/app/src/main/res/layout/item_plan_location.xml
@@ -47,10 +47,10 @@
 
         <ImageView
             android:id="@+id/iv_plan_location_check"
-            android:layout_width="1dp"
-            android:layout_height="0dp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             android:layout_marginEnd="@dimen/spacing14"
-            android:src="@{planLocationItem.isSelected ? @drawable/ic_all_check_selected_24 : @drawable/ic_all_check_default_24}"
+            android:src="@{planLocationItem.isSelected ? @drawable/ic_all_check_selected_24 : @drawable/ic_all_check_default_24, default=@drawable/ic_all_check_default_24}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,7 +97,7 @@
 ]
     <!-- plan Recruitment -->
     <string name="plan_recruitment_title">몇 명의 핑글러들과\n만날까요?</string>
-    <string name="plan_recruitment_description">개최자를 포함하여,\n최소 1명부터 참여 인원을 선택해주세요</string>
+    <string name="plan_recruitment_description">본인을 포함하여,\n최소 1명부터 참여 인원을 선택해주세요</string>
     <string name="plan_recruitment_minus">-</string>
     <string name="plan_recruitment_plus">+</string>
     <string name="plan_recruitment_default">1</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -100,5 +100,5 @@
     <string name="plan_recruitment_description">본인을 포함하여,\n최소 1명부터 참여 인원을 선택해주세요</string>
     <string name="plan_recruitment_minus">-</string>
     <string name="plan_recruitment_plus">+</string>
-    <string name="plan_recruitment_default">1</string>
+    <string name="plan_recruitment_snackbar">최대 선택 가능 인원은 99명이에요!</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,4 +36,14 @@
 
     <!-- map modal -->
     <string name="map_modal_description">이 핑글에 참여할까요?</string>
+
+    <!-- plan Category -->
+    <string name="plan_category_title">개최할 핑글을\n선택해주세요</string>
+
+    <!-- plan Recruitment -->
+    <string name="plan_recruitment_title">몇 명의 핑글러들과\n만날까요?</string>
+    <string name="plan_recruitment_description">개최자를 포함하여,\n최소 1명부터 참여 인원을 선택해주세요</string>
+    <string name="plan_recruitment_minus">-</string>
+    <string name="plan_recruitment_plus">+</string>
+    <string name="plan_recruitment_default">1</string>
 </resources>


### PR DESCRIPTION
## Related issue 🛠
- closed #39 

## Work Description ✏️
- [x] 최소(기본) 인원 1명, 최대 설정 인원 99명으로 설정
- [x] +, -버튼 활성화 및 비활성화
    - [x] 인원 1명인 경우 - 버튼 비활성화
    - [x] 버튼 비활성화 시 textView 내 텍스트 색상/버튼 클릭가능여부/배경색상 변화 필요
- [x] EditText 입력 시 사용자에게 숫자 키패드만 띄우기
- [x] Snackbar 
    - [x] 99명인 상태에서 +를 누르는 경우 출력
    - [x] 2초간 노출 후 페이드아웃 애니메이션

## Screenshot 📸
https://github.com/TeamPINGLE/PINGLE-ANDROID/assets/83916472/000b3de1-d547-4db9-b5f7-838dc0736ae5

## Uncompleted Tasks 😅
- [x] 다음 프로세스 이동 버튼은 최종 완성되면 추가

## To Reviewers 📢
**궁금증**
뷰모델에서 private val, 그리고 get()을 이용해서 하니 자꾸 get할 수 없다면서 오류가 발생했습니다..
수정하면 또 null safety 문제가 발생하구.. 결국에는 뷰모델에서 MutableStateFlow를 val로 선언해서 요리조리 바꾸었는데요
문제가 없을까요?
사실 이 private val와 get 때문에 3시간을 잡아무겄습니다ㅜ.
짱나네