### PR TITLE
[feat] 개최 프로세스 - 유저 정보 불러오기 API 연동

### DIFF
--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/plan/PlanViewModel.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/plan/PlanViewModel.kt
@@ -228,7 +228,7 @@ class PlanViewModel @Inject constructor(
 
     fun getUserInfo() {
         viewModelScope.launch {
-            _userInfoState.value =UiState.Loading
+            _userInfoState.value = UiState.Loading
             runCatching {
                 getUserInfoUseCase().collect() { userInfo ->
                     _userInfoState.value = UiState.Success(userInfo)

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/plan/planlocation/PlanLocationFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/plan/planlocation/PlanLocationFragment.kt
@@ -78,7 +78,7 @@ class PlanLocationFragment :
     }
 
     override fun onDestroyView() {
-        super.onDestroyView()
         binding.rvPlanLocationList.adapter = null
+        super.onDestroyView()
     }
 }

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/plan/plansummaryconfirmation/PlanSummaryConfirmationFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/plan/plansummaryconfirmation/PlanSummaryConfirmationFragment.kt
@@ -37,8 +37,8 @@ class PlanSummaryConfirmationFragment :
             tvPlanSummaryConfirmationName.text = viewModel.planTitle.value
             tvPlanSummaryConfirmationCalenderDetail.text =
                 convertDateFormat(viewModel.planDate.value) + "\n" + convertTimeFormat(viewModel.startTime.value) + " ~ " + convertTimeFormat(
-                    viewModel.endTime.value
-                )
+                viewModel.endTime.value
+            )
             tvPlanSummaryConfirmationMapDetail.text = viewModel.selectedLocation.value?.location
             tvPlanSummaryConfirmationRecruitmentDetail.text = getString(
                 R.string.plan_summary_confirmation_recruitment_number,
@@ -50,8 +50,9 @@ class PlanSummaryConfirmationFragment :
     private fun collectData() {
         viewModel.userInfoState.flowWithLifecycle(lifecycle).onEach { userInfoState ->
             when (userInfoState) {
-                is UiState.Success -> binding.tvPlanSummaryConfirmationOwnerName.text =
-                    userInfoState.data.name
+                is UiState.Success ->
+                    binding.tvPlanSummaryConfirmationOwnerName.text =
+                        userInfoState.data.name
 
                 else -> Unit
             }

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/plan/plansummaryconfirmation/PlanSummaryConfirmationFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/plan/plansummaryconfirmation/PlanSummaryConfirmationFragment.kt
@@ -3,12 +3,17 @@ package org.sopt.pingle.presentation.ui.main.plan.plansummaryconfirmation
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import org.sopt.pingle.R
 import org.sopt.pingle.databinding.FragmentPlanSummaryConfirmationBinding
 import org.sopt.pingle.presentation.ui.main.plan.PlanViewModel
 import org.sopt.pingle.util.base.BindingFragment
 import org.sopt.pingle.util.fragment.colorOf
+import org.sopt.pingle.util.view.UiState
 
 @AndroidEntryPoint
 class PlanSummaryConfirmationFragment :
@@ -18,30 +23,44 @@ class PlanSummaryConfirmationFragment :
         super.onViewCreated(view, savedInstanceState)
 
         initLayout()
+        collectData()
     }
 
     private fun initLayout() {
-        viewModel.selectedCategory.value?.let { category ->
-            with(binding) {
+        viewModel.getUserInfo()
+
+        with(binding) {
+            viewModel.selectedCategory.value?.let { category ->
                 badgePlanSummaryConfirmationCategory.setBadgeCategoryType(category)
                 tvPlanSummaryConfirmationName.setTextColor(colorOf((category.textColor)))
-                tvPlanSummaryConfirmationName.text = viewModel.planTitle.value
-                // TODO API연결해서 개최자명 넣기
-                tvPlanSummaryConfirmationOwnerName.text = "개최자"
-                tvPlanSummaryConfirmationCalenderDetail.text =
-                    convertDateFormat(viewModel.planDate.value) + "\n" + convertTimeFormat(viewModel.startTime.value) + " ~ " + convertTimeFormat(
+            }
+            tvPlanSummaryConfirmationName.text = viewModel.planTitle.value
+            tvPlanSummaryConfirmationCalenderDetail.text =
+                convertDateFormat(viewModel.planDate.value) + "\n" + convertTimeFormat(viewModel.startTime.value) + " ~ " + convertTimeFormat(
                     viewModel.endTime.value
                 )
-                tvPlanSummaryConfirmationMapDetail.text = viewModel.selectedLocation.value?.location
-                tvPlanSummaryConfirmationRecruitmentDetail.text = getString(
-                    R.string.plan_summary_confirmation_recruitment_number,
-                    viewModel.selectedRecruitment.value
-                )
-            }
+            tvPlanSummaryConfirmationMapDetail.text = viewModel.selectedLocation.value?.location
+            tvPlanSummaryConfirmationRecruitmentDetail.text = getString(
+                R.string.plan_summary_confirmation_recruitment_number,
+                viewModel.selectedRecruitment.value
+            )
         }
     }
 
-    private fun convertTimeFormat(time: String): String = time.substring(TIME_START_INDEX, TIME_END_INDEX)
+    private fun collectData() {
+        viewModel.userInfoState.flowWithLifecycle(lifecycle).onEach { userInfoState ->
+            when (userInfoState) {
+                is UiState.Success -> binding.tvPlanSummaryConfirmationOwnerName.text =
+                    userInfoState.data.name
+
+                else -> Unit
+            }
+        }.launchIn(lifecycleScope)
+    }
+
+    private fun convertTimeFormat(time: String): String =
+        time.substring(TIME_START_INDEX, TIME_END_INDEX)
+
     private fun convertDateFormat(date: String): String {
         val year = date.substring(YEAR_START_INDEX, YEAR_END_INDEX)
         val month = date.substring(MONTH_START_INDEX, MONTH_END_INDEX)


### PR DESCRIPTION
## Related issue 🛠
- closed #115

## Work Description ✏️
- 개최 프로세스 뷰에서 유저 정보 불러오기 API를 연동하였습니다.

## Screenshot 📸
<img width="296" alt="스크린샷 2024-01-12 오후 9 31 25" src="https://github.com/TeamPINGLE/PINGLE-ANDROID/assets/103172971/adb24f6b-e7c3-4426-bff5-23e2e1fd68e6">


## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
ㅋㅋ