### PR TITLE
[feat] 메인 지도 뷰 - 카드 가로 스크롤 기능 추가

### DIFF
--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/map/MapCardAdapter.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/map/MapCardAdapter.kt
@@ -1,0 +1,47 @@
+package org.sopt.pingle.presentation.ui.main.home.map
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.ListAdapter
+import org.sopt.pingle.databinding.ItemMapPingleCardBinding
+import org.sopt.pingle.domain.model.PingleEntity
+import org.sopt.pingle.util.view.ItemDiffCallback
+
+class MapCardAdapter(
+    private val navigateToWebViewWithChatLink: (String) -> Unit,
+    private val showMapJoinModalDialogFragment: (PingleEntity) -> Unit,
+    private val showMapCancelModalDialogFragment: (PingleEntity) -> Unit
+) : ListAdapter<PingleEntity, MapCardViewHolder>(
+    ItemDiffCallback<PingleEntity>(
+        onContentsTheSame = { old, new -> old == new },
+        onItemsTheSame = { old, new -> old.id == new.id }
+    )
+) {
+    private var _pinId: Long = DEFAULT_VALUE
+    val pinId get() = _pinId
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MapCardViewHolder =
+        MapCardViewHolder(
+            ItemMapPingleCardBinding.inflate(LayoutInflater.from(parent.context), parent, false),
+            navigateToWebViewWithChatLink,
+            showMapJoinModalDialogFragment,
+            showMapCancelModalDialogFragment
+        )
+
+    override fun onBindViewHolder(holder: MapCardViewHolder, position: Int) {
+        holder.onBind(pinId = _pinId, pingleEntity = currentList[position])
+    }
+
+    fun setPinId(pinId: Long) {
+        this._pinId = pinId
+    }
+
+    fun clearData() {
+        _pinId = DEFAULT_VALUE
+        submitList(emptyList())
+    }
+
+    companion object {
+        const val DEFAULT_VALUE = -1L
+    }
+}

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/map/MapCardViewHolder.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/map/MapCardViewHolder.kt
@@ -1,0 +1,28 @@
+package org.sopt.pingle.presentation.ui.main.home.map
+
+import androidx.recyclerview.widget.RecyclerView
+import org.sopt.pingle.databinding.ItemMapPingleCardBinding
+import org.sopt.pingle.domain.model.PingleEntity
+
+class MapCardViewHolder(
+    private val binding: ItemMapPingleCardBinding,
+    private val navigateToWebView: (String) -> Unit,
+    private val showMapJoinModalDialogFragment: (PingleEntity) -> Unit,
+    private val showMapCancelModalDialogFragment: (PingleEntity) -> Unit
+) : RecyclerView.ViewHolder(binding.root) {
+    fun onBind(pinId: Long, pingleEntity: PingleEntity) {
+        with(binding.cardMapPingleCard) {
+            initLayout(pingleEntity)
+            setPinId(pinId)
+            setOnChatButtonClick {
+                navigateToWebView(pingleEntity.chatLink)
+            }
+            setOnParticipateButtonClick {
+                when (pingleEntity.isParticipating) {
+                    true -> showMapCancelModalDialogFragment(pingleEntity)
+                    false -> showMapJoinModalDialogFragment(pingleEntity)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/map/MapFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/map/MapFragment.kt
@@ -2,6 +2,7 @@ package org.sopt.pingle.presentation.ui.main.home.map
 
 import android.Manifest
 import android.content.pm.PackageManager
+import android.graphics.Rect
 import android.os.Bundle
 import android.view.View
 import androidx.activity.result.contract.ActivityResultContracts
@@ -11,6 +12,7 @@ import androidx.fragment.app.commit
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.RecyclerView
 import com.google.android.gms.location.LocationServices
 import com.naver.maps.geometry.LatLng
 import com.naver.maps.map.CameraAnimation
@@ -39,6 +41,7 @@ import org.sopt.pingle.util.fragment.navigateToFragment
 import org.sopt.pingle.util.fragment.navigateToWebView
 import org.sopt.pingle.util.fragment.stringOf
 import org.sopt.pingle.util.view.UiState
+import org.sopt.pingle.util.view.toPx
 
 @AndroidEntryPoint
 class MapFragment : BindingFragment<FragmentMapBinding>(R.layout.fragment_map), OnMapReadyCallback {
@@ -111,8 +114,26 @@ class MapFragment : BindingFragment<FragmentMapBinding>(R.layout.fragment_map), 
             showMapCancelModalDialogFragment = ::showMapCancelModalDialogFragment
         )
 
+        with(binding.vpMapCard) {
+            adapter = mapCardAdapter
+            addItemDecoration(object : RecyclerView.ItemDecoration() {
+                override fun getItemOffsets(
+                    outRect: Rect,
+                    view: View,
+                    parent: RecyclerView,
+                    state: RecyclerView.State
+                ) {
+                    outRect.right = VIEWPAGER_ITEM_OFFSET.toPx()
+                    outRect.left = VIEWPAGER_ITEM_OFFSET.toPx()
+                }
+            })
+            offscreenPageLimit = 1
+            setPageTransformer { page, position ->
+                page.translationX = (VIEWPAGER_PAGE_TRANSFORMER).toPx() * position
+            }
+        }
+
         with(binding) {
-            vpMapCard.adapter = mapCardAdapter
             chipMapCategoryPlay.setChipCategoryType(CategoryType.PLAY)
             chipMapCategoryStudy.setChipCategoryType(CategoryType.STUDY)
             chipMapCategoryMulti.setChipCategoryType(CategoryType.MULTI)
@@ -317,5 +338,8 @@ class MapFragment : BindingFragment<FragmentMapBinding>(R.layout.fragment_map), 
 
         private const val MIN_ZOOM = 5.5
         private const val DEFAULT_VALUE = -1L
+
+        private const val VIEWPAGER_ITEM_OFFSET = 24
+        private const val VIEWPAGER_PAGE_TRANSFORMER = -40
     }
 }

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/map/MapFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/map/MapFragment.kt
@@ -218,7 +218,6 @@ class MapFragment : BindingFragment<FragmentMapBinding>(R.layout.fragment_map), 
                     mapCardAdapter.pinId.takeIf { it != DEFAULT_VALUE }?.let { pinId ->
                         mapViewModel.getPingleList(pinId = pinId)
                     }
-
                 }
 
                 else -> Unit
@@ -228,11 +227,11 @@ class MapFragment : BindingFragment<FragmentMapBinding>(R.layout.fragment_map), 
 
     private fun setLocationTrackingMode() {
         if (LOCATION_PERMISSIONS.any { permission ->
-                ContextCompat.checkSelfPermission(
+            ContextCompat.checkSelfPermission(
                     requireContext(),
                     permission
                 ) == PackageManager.PERMISSION_GRANTED
-            }
+        }
         ) {
             locationSource = FusedLocationSource(this, LOCATION_PERMISSION_REQUEST_CODE)
 

--- a/app/src/main/res/layout/fragment_map.xml
+++ b/app/src/main/res/layout/fragment_map.xml
@@ -89,7 +89,6 @@
             android:id="@+id/vp_map_card"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/card_horizontal_margin"
             android:layout_marginBottom="8dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/fragment_map.xml
+++ b/app/src/main/res/layout/fragment_map.xml
@@ -85,10 +85,9 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent" />
 
-        <org.sopt.pingle.util.component.PingleCard
-            android:id="@+id/card_map"
+        <androidx.viewpager2.widget.ViewPager2
+            android:id="@+id/vp_map_card"
             android:layout_width="0dp"
-            android:visibility="invisible"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/card_horizontal_margin"
             android:layout_marginBottom="8dp"

--- a/app/src/main/res/layout/item_map_pingle_card.xml
+++ b/app/src/main/res/layout/item_map_pingle_card.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <org.sopt.pingle.util.component.PingleCard
+            android:id="@+id/card_map_pingle_card"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>


### PR DESCRIPTION
## Related issue 🛠
- closed #140 

## Work Description ✏️
- 메인 지도 뷰에 카드 가로 스크롤 기능을 추가하였습니다.

## Screenshot 📸
https://github.com/TeamPINGLE/PINGLE-ANDROID/assets/103172971/8ea51775-0ed5-411f-8f9f-3a989732ba0a

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
기획 측에 물어봤더니 바텀 네비 로직 수정보다 카드 가로 스크롤 기능 추가가 우선 순위라고 해서 이 기능 먼저 구현했습니다.