### PR TITLE
[fix] 메인 지도 뷰 카드 올라간 채로 카테고리 변경했을 때 카드 안 내려가는 버그 수정

### DIFF
--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/map/MapFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/map/MapFragment.kt
@@ -181,6 +181,7 @@ class MapFragment : BindingFragment<FragmentMapBinding>(R.layout.fragment_map), 
                     is UiState.Success -> {
                         if (::naverMap.isInitialized) {
                             makeMarkers(uiState.data)
+                            mapCardAdapter.clearData()
                             mapViewModel.clearSelectedMarkerPosition()
                         }
                     }


### PR DESCRIPTION
## Related issue 🛠
- closed #150 

## Work Description ✏️
- 메인 지도 뷰에서 카드 올라간 채로 카테고리를 변경했을 때 카드가 내려가지 않는 버그를 수정했습니다.

## Screenshot 📸
https://github.com/TeamPINGLE/PINGLE-ANDROID/assets/103172971/2c5e7e68-d82d-42cc-866e-663d1757ade7


## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
여기까지 머지하고 QA 잘 반영됐는지 확인합시당