### PR TITLE
[fix] 단체 검색, 장소 검색 뷰 - 아무것도 입력하지 않은 경우 서버통신하지 않도록 수정

### DIFF
--- a/app/src/main/java/org/sopt/pingle/presentation/ui/joingroup/JoinGroupSearchActivity.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/joingroup/JoinGroupSearchActivity.kt
@@ -50,13 +50,13 @@ class JoinGroupSearchActivity :
         }
 
         binding.ivJoinGroupSearchIcon.setOnClickListener {
-            viewModel.joinGroupSearchState(binding.etJoinGroupSearch.text.toString())
+            if(binding.etJoinGroupSearch.text.isNotBlank()) viewModel.joinGroupSearchState(binding.etJoinGroupSearch.text.toString())
             hideKeyboard(binding.etJoinGroupSearch)
         }
 
         binding.etJoinGroupSearch.setOnKeyListener { _, keyCode, event ->
             if (keyCode == KeyEvent.KEYCODE_ENTER && event.action == KeyEvent.ACTION_DOWN) {
-                viewModel.joinGroupSearchState(binding.etJoinGroupSearch.text.toString())
+                if(binding.etJoinGroupSearch.text.isNotBlank()) viewModel.joinGroupSearchState(binding.etJoinGroupSearch.text.toString())
                 hideKeyboard(binding.etJoinGroupSearch)
                 return@setOnKeyListener true
             }

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/joingroup/JoinGroupSearchActivity.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/joingroup/JoinGroupSearchActivity.kt
@@ -50,13 +50,13 @@ class JoinGroupSearchActivity :
         }
 
         binding.ivJoinGroupSearchIcon.setOnClickListener {
-            if(binding.etJoinGroupSearch.text.isNotBlank()) viewModel.joinGroupSearchState(binding.etJoinGroupSearch.text.toString())
+            if (binding.etJoinGroupSearch.text.isNotBlank()) viewModel.joinGroupSearchState(binding.etJoinGroupSearch.text.toString())
             hideKeyboard(binding.etJoinGroupSearch)
         }
 
         binding.etJoinGroupSearch.setOnKeyListener { _, keyCode, event ->
             if (keyCode == KeyEvent.KEYCODE_ENTER && event.action == KeyEvent.ACTION_DOWN) {
-                if(binding.etJoinGroupSearch.text.isNotBlank()) viewModel.joinGroupSearchState(binding.etJoinGroupSearch.text.toString())
+                if (binding.etJoinGroupSearch.text.isNotBlank()) viewModel.joinGroupSearchState(binding.etJoinGroupSearch.text.toString())
                 hideKeyboard(binding.etJoinGroupSearch)
                 return@setOnKeyListener true
             }

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/plan/planlocation/PlanLocationFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/plan/planlocation/PlanLocationFragment.kt
@@ -42,7 +42,7 @@ class PlanLocationFragment :
         }
 
         binding.ivPlanLocationSearchBtn.setOnClickListener {
-            if(binding.etPlanLocationSearch.text.isNotBlank()) {
+            if (binding.etPlanLocationSearch.text.isNotBlank()) {
                 planLocationViewModel.getPlanLocationList(binding.etPlanLocationSearch.text.toString())
             }
             requireContext().hideKeyboard(binding.etPlanLocationSearch)
@@ -51,14 +51,14 @@ class PlanLocationFragment :
         binding.etPlanLocationSearch.setOnKeyListener(
             View.OnKeyListener { _, keyCode, event ->
                 if (keyCode == KeyEvent.KEYCODE_ENTER && event.action == KeyEvent.ACTION_UP) {
-                    if(binding.etPlanLocationSearch.text.isNotBlank()) {
+                    if (binding.etPlanLocationSearch.text.isNotBlank()) {
                         planLocationViewModel.getPlanLocationList(binding.etPlanLocationSearch.text.toString())
                     }
                     requireContext().hideKeyboard(binding.etPlanLocationSearch)
                     return@OnKeyListener true
                 }
                 false
-            },
+            }
         )
     }
 

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/plan/planlocation/PlanLocationFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/plan/planlocation/PlanLocationFragment.kt
@@ -42,19 +42,23 @@ class PlanLocationFragment :
         }
 
         binding.ivPlanLocationSearchBtn.setOnClickListener {
+            if(binding.etPlanLocationSearch.text.isNotBlank()) {
+                planLocationViewModel.getPlanLocationList(binding.etPlanLocationSearch.text.toString())
+            }
             requireContext().hideKeyboard(binding.etPlanLocationSearch)
-            planLocationViewModel.getPlanLocationList(binding.etPlanLocationSearch.text.toString())
         }
 
         binding.etPlanLocationSearch.setOnKeyListener(
             View.OnKeyListener { _, keyCode, event ->
                 if (keyCode == KeyEvent.KEYCODE_ENTER && event.action == KeyEvent.ACTION_UP) {
-                    planLocationViewModel.getPlanLocationList(binding.etPlanLocationSearch.text.toString())
+                    if(binding.etPlanLocationSearch.text.isNotBlank()) {
+                        planLocationViewModel.getPlanLocationList(binding.etPlanLocationSearch.text.toString())
+                    }
                     requireContext().hideKeyboard(binding.etPlanLocationSearch)
                     return@OnKeyListener true
                 }
                 false
-            }
+            },
         )
     }
 


### PR DESCRIPTION
## Related issue 🛠
- closed #152 

## Work Description ✏️
- [x] 단체 검색에서 사용자가 아무것도 입력 안했을 때 서버통신하지 않도록 수정
- [x] 개최 프로세스 - 장소 검색에서 사용자가 아무것도 입력하지 않았을 때 서버통신하지 않도록 수정

## Screenshot 📸
뷰에 변화 없으므로 생략

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
로그 찍어봤는데 문제 없이 서버통신을 실행하지 않습니당.
끗.