### PR TITLE
[feat] 안드로이드 기본 이전 버튼 스택 관리

### DIFF
--- a/app/src/main/java/org/sopt/pingle/presentation/ui/plan/PlanActivity.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/plan/PlanActivity.kt
@@ -97,18 +97,6 @@ class PlanActivity : BindingActivity<ActivityPlanBinding>(R.layout.activity_plan
         }
     }
 
-    private fun navigateToPreviousPage() {
-        when (binding.vpPlan.currentItem) {
-            0 -> {
-                navigateToPlanAnnouncement()
-            }
-
-            else -> {
-                binding.vpPlan.currentItem--
-            }
-        }
-    }
-
     private fun collectData() {
         planViewModel.currentPage.flowWithLifecycle(lifecycle).onEach { currentPage ->
             binding.planProgress.progress = currentPage.toFloat() + 1f
@@ -142,6 +130,18 @@ class PlanActivity : BindingActivity<ActivityPlanBinding>(R.layout.activity_plan
             clickBtn = {},
             clickTextBtn = { finish() }
         ).show(supportFragmentManager, EXIT_MODAL)
+    }
+
+    private fun navigateToPreviousPage() {
+        when (binding.vpPlan.currentItem) {
+            0 -> {
+                navigateToPlanAnnouncement()
+            }
+
+            else -> {
+                binding.vpPlan.currentItem--
+            }
+        }
     }
 
     private fun navigateToPlanAnnouncement() {

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/plan/PlanActivity.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/plan/PlanActivity.kt
@@ -90,18 +90,22 @@ class PlanActivity : BindingActivity<ActivityPlanBinding>(R.layout.activity_plan
             }
         }
         binding.toolbar.ivAllTopbarArrowWithTitleArrowLeft.setOnClickListener {
-            when (binding.vpPlan.currentItem) {
-                0 -> {
-                    navigateToPlanAnnouncement()
-                }
-
-                else -> {
-                    binding.vpPlan.currentItem--
-                }
-            }
+            navigateToPreviousPage()
         }
         binding.tvPlanClose.setOnClickListener {
             showExitModalDialogFragment()
+        }
+    }
+
+    private fun navigateToPreviousPage() {
+        when (binding.vpPlan.currentItem) {
+            0 -> {
+                navigateToPlanAnnouncement()
+            }
+
+            else -> {
+                binding.vpPlan.currentItem--
+            }
         }
     }
 
@@ -158,15 +162,7 @@ class PlanActivity : BindingActivity<ActivityPlanBinding>(R.layout.activity_plan
     private fun onBackPressedBtn() {
         onBackPressed = object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
-                when (binding.vpPlan.currentItem) {
-                    0 -> {
-                        navigateToPlanAnnouncement()
-                    }
-
-                    else -> {
-                        binding.vpPlan.currentItem--
-                    }
-                }
+                navigateToPreviousPage()
             }
         }
         onBackPressedDispatcher.addCallback(this, onBackPressed)

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/plan/PlanActivity.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/plan/PlanActivity.kt
@@ -69,12 +69,12 @@ class PlanActivity : BindingActivity<ActivityPlanBinding>(R.layout.activity_plan
             this.adapter = adapter
             isUserInputEnabled = false
             registerOnPageChangeCallback(object :
-                    ViewPager2.OnPageChangeCallback() {
-                    override fun onPageSelected(position: Int) {
-                        super.onPageSelected(position)
-                        planViewModel.setCurrentPage(position)
-                    }
-                })
+                ViewPager2.OnPageChangeCallback() {
+                override fun onPageSelected(position: Int) {
+                    super.onPageSelected(position)
+                    planViewModel.setCurrentPage(position)
+                }
+            })
         }
     }
 
@@ -84,6 +84,7 @@ class PlanActivity : BindingActivity<ActivityPlanBinding>(R.layout.activity_plan
                 fragmentList.size - 1 -> {
                     planViewModel.postPlanMeeting()
                 }
+
                 else -> {
                     binding.vpPlan.currentItem++
                 }
@@ -128,7 +129,7 @@ class PlanActivity : BindingActivity<ActivityPlanBinding>(R.layout.activity_plan
             buttonText = getString(R.string.plan_exit_modal_dialog_btn_text),
             textButtonText = getString(R.string.plan_exit_modal_dialog_text_btn_text),
             clickBtn = {},
-            clickTextBtn = { finish() }
+            clickTextBtn = { finish() },
         ).show(supportFragmentManager, EXIT_MODAL)
     }
 

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/plan/PlanActivity.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/plan/PlanActivity.kt
@@ -3,6 +3,7 @@ package org.sopt.pingle.presentation.ui.plan
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.flowWithLifecycle
@@ -30,6 +31,8 @@ import org.sopt.pingle.util.view.UiState
 class PlanActivity : BindingActivity<ActivityPlanBinding>(R.layout.activity_plan) {
     private val planViewModel: PlanViewModel by viewModels()
     private lateinit var fragmentList: ArrayList<Fragment>
+    private lateinit var onBackPressed: OnBackPressedCallback
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -39,6 +42,7 @@ class PlanActivity : BindingActivity<ActivityPlanBinding>(R.layout.activity_plan
         initView()
         addListeners()
         collectData()
+        onBackPressedBtn()
     }
 
     private fun initView() {
@@ -77,7 +81,6 @@ class PlanActivity : BindingActivity<ActivityPlanBinding>(R.layout.activity_plan
     private fun addListeners() {
         binding.btnPlan.setOnClickListener {
             when (binding.vpPlan.currentItem) {
-                // TODO 핑글 개최 api 연동
                 fragmentList.size - 1 -> {
                     planViewModel.postPlanMeeting()
                 }
@@ -150,6 +153,23 @@ class PlanActivity : BindingActivity<ActivityPlanBinding>(R.layout.activity_plan
             startActivity(this)
             finish()
         }
+    }
+
+    private fun onBackPressedBtn() {
+        onBackPressed = object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                when (binding.vpPlan.currentItem) {
+                    0 -> {
+                        navigateToPlanAnnouncement()
+                    }
+
+                    else -> {
+                        binding.vpPlan.currentItem--
+                    }
+                }
+            }
+        }
+        onBackPressedDispatcher.addCallback(this, onBackPressed)
     }
 
     companion object {

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/plan/PlanActivity.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/plan/PlanActivity.kt
@@ -69,12 +69,12 @@ class PlanActivity : BindingActivity<ActivityPlanBinding>(R.layout.activity_plan
             this.adapter = adapter
             isUserInputEnabled = false
             registerOnPageChangeCallback(object :
-                ViewPager2.OnPageChangeCallback() {
-                override fun onPageSelected(position: Int) {
-                    super.onPageSelected(position)
-                    planViewModel.setCurrentPage(position)
-                }
-            })
+                    ViewPager2.OnPageChangeCallback() {
+                    override fun onPageSelected(position: Int) {
+                        super.onPageSelected(position)
+                        planViewModel.setCurrentPage(position)
+                    }
+                })
         }
     }
 
@@ -129,7 +129,7 @@ class PlanActivity : BindingActivity<ActivityPlanBinding>(R.layout.activity_plan
             buttonText = getString(R.string.plan_exit_modal_dialog_btn_text),
             textButtonText = getString(R.string.plan_exit_modal_dialog_text_btn_text),
             clickBtn = {},
-            clickTextBtn = { finish() },
+            clickTextBtn = { finish() }
         ).show(supportFragmentManager, EXIT_MODAL)
     }
 


### PR DESCRIPTION
## Related issue 🛠
- closed #159 

## Work Description ✏️
- 안드로이드에 기본으로 있는 이전 버튼 클릭 시 스택에 저장된 액티비티가 실행되는 것을 방지하고 개최 프로세스의 이전 프래그먼트로 이동하도록 구현합니다. (화면 좌측 상단의 이전 버튼과 같은 역할을 하도록 구현)

## Screenshot 📸
https://github.com/TeamPINGLE/PINGLE-ANDROID/assets/83916472/14ee59ed-caee-4450-a2cc-aa0bce2bc888

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
뭔가 어떤건 사악~ 이전 화면으로 가는데 어떤 페이지는 뚝. 가서 왜 이러는지 머르겠네요;;
왓츠매럴인지