### PR TITLE
[fix] 메인 지도뷰/리스트뷰 - 참여현황 뷰 개최자 여러명인 버그 수정 

### DIFF
--- a/app/src/main/java/org/sopt/pingle/presentation/ui/participant/ParticipantViewHolder.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/participant/ParticipantViewHolder.kt
@@ -7,15 +7,14 @@ import org.sopt.pingle.databinding.ItemParticipantBinding
 class ParticipantViewHolder(private val binding: ItemParticipantBinding) :
     RecyclerView.ViewHolder(binding.root) {
     fun onBind(item: String) {
-        binding.tvParticipantName.text = item
-        binding.tvParticipantOwnerName.text = item
+        with(binding) {
+            tvParticipantName.text = item
+            tvParticipantOwnerName.text = item
 
-        if (absoluteAdapterPosition == DEFAULT_POSITION) {
-            with(binding) {
-                tvParticipantName.visibility = View.INVISIBLE
-                tvParticipantOwner.visibility = View.VISIBLE
-                tvParticipantOwnerName.visibility = View.VISIBLE
-            }
+            val isDefaultPosition = absoluteAdapterPosition == DEFAULT_POSITION
+            tvParticipantName.visibility = if (isDefaultPosition) View.INVISIBLE else View.VISIBLE
+            tvParticipantOwner.visibility = if (isDefaultPosition) View.VISIBLE else View.INVISIBLE
+            tvParticipantOwnerName.visibility = if (isDefaultPosition) View.VISIBLE else View.INVISIBLE
         }
     }
 

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/participant/ParticipantViewHolder.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/participant/ParticipantViewHolder.kt
@@ -6,19 +6,22 @@ import org.sopt.pingle.databinding.ItemParticipantBinding
 
 class ParticipantViewHolder(private val binding: ItemParticipantBinding) :
     RecyclerView.ViewHolder(binding.root) {
-    fun onBind(item: String) {
+    fun onBind(name: String) {
         with(binding) {
-            tvParticipantName.text = item
-            tvParticipantOwnerName.text = item
-
-            val isDefaultPosition = absoluteAdapterPosition == DEFAULT_POSITION
-            tvParticipantName.visibility = if (isDefaultPosition) View.INVISIBLE else View.VISIBLE
-            tvParticipantOwner.visibility = if (isDefaultPosition) View.VISIBLE else View.INVISIBLE
-            tvParticipantOwnerName.visibility = if (isDefaultPosition) View.VISIBLE else View.INVISIBLE
+            (absoluteAdapterPosition == ORGANIZER_POSITION).let { isOrganizerPosition ->
+                if (isOrganizerPosition) {
+                    tvParticipantOwnerName.text = name
+                } else {
+                    tvParticipantName.text = name
+                }
+                tvParticipantName.visibility = if (isOrganizerPosition) View.INVISIBLE else View.VISIBLE
+                tvParticipantOwner.visibility = if (isOrganizerPosition) View.VISIBLE else View.INVISIBLE
+                tvParticipantOwnerName.visibility = if (isOrganizerPosition) View.VISIBLE else View.INVISIBLE
+            }
         }
     }
 
     companion object {
-        const val DEFAULT_POSITION = 0
+        const val ORGANIZER_POSITION = 0
     }
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #181 

## Work Description ✏️
- 메인 지도뷰/리스트뷰에 해당하는 참여현황 뷰에서 리사이클러뷰 재생성에 따라 개최자로 표시되는 인원이 여러명 발생하는 버그를 수정합니다.

## Screenshot 📸
https://github.com/TeamPINGLE/PINGLE-ANDROID/assets/83916472/dad28938-1638-4e1c-b935-5e9d7d5b3363



## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
다들 보고싶어염,,,