### PR TITLE
[feat] 커스텀 Search Bar 적용

### DIFF
--- a/app/src/main/java/org/sopt/pingle/presentation/ui/joingroup/JoinGroupSearchActivity.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/joingroup/JoinGroupSearchActivity.kt
@@ -41,34 +41,35 @@ class JoinGroupSearchActivity :
     }
 
     private fun addListeners() {
-        binding.includeJoinGroupSearchTopbar.ivAllTopbarArrowWithTitleArrowLeft.setOnClickListener {
-            finish()
-        }
-
-        binding.root.setOnClickListener {
-            hideKeyboard(binding.etJoinGroupSearch)
-        }
-
-        binding.ivJoinGroupSearchIcon.setOnClickListener {
-            if (binding.etJoinGroupSearch.text.isNotBlank()) viewModel.getJoinGroupSearch(binding.etJoinGroupSearch.text.toString())
-            hideKeyboard(binding.etJoinGroupSearch)
-        }
-
-        binding.etJoinGroupSearch.setOnKeyListener { _, keyCode, event ->
-            if (keyCode == KeyEvent.KEYCODE_ENTER && event.action == KeyEvent.ACTION_DOWN) {
-                if (binding.etJoinGroupSearch.text.isNotBlank()) viewModel.getJoinGroupSearch(binding.etJoinGroupSearch.text.toString())
-                hideKeyboard(binding.etJoinGroupSearch)
-                return@setOnKeyListener true
+        with(binding) {
+            includeJoinGroupSearchTopbar.ivAllTopbarArrowWithTitleArrowLeft.setOnClickListener {
+                finish()
             }
-            false
-        }
 
-        binding.tvJoinGroupSearchCreate.setOnClickListener {
-            startActivity(navigateToWebView(OnBoardingActivity.NEW_GROUP_LINK))
-        }
+            (pingleSearchJoinGroupSearch.editText).let { searchEditText ->
+                root.setOnClickListener {
+                    hideKeyboard(searchEditText)
+                }
 
-        binding.btnJoinGroupCodeNext.setOnClickListener {
-            navigateToJoinGroupCode()
+                searchEditText.setOnKeyListener { _, keyCode, event ->
+                    if (keyCode == KeyEvent.KEYCODE_ENTER && event.action == KeyEvent.ACTION_DOWN) {
+                        if (searchEditText.text.isNotBlank()) viewModel.getJoinGroupSearch(
+                            searchEditText.text.toString()
+                        )
+                        hideKeyboard(searchEditText)
+                        return@setOnKeyListener true
+                    }
+                    false
+                }
+            }
+
+            tvJoinGroupSearchCreate.setOnClickListener {
+                startActivity(navigateToWebView(OnBoardingActivity.NEW_GROUP_LINK))
+            }
+
+            btnJoinGroupCodeNext.setOnClickListener {
+                navigateToJoinGroupCode()
+            }
         }
     }
 

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/joingroup/JoinGroupSearchActivity.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/joingroup/JoinGroupSearchActivity.kt
@@ -53,9 +53,11 @@ class JoinGroupSearchActivity :
 
                 searchEditText.setOnKeyListener { _, keyCode, event ->
                     if (keyCode == KeyEvent.KEYCODE_ENTER && event.action == KeyEvent.ACTION_DOWN) {
-                        if (searchEditText.text.isNotBlank()) viewModel.getJoinGroupSearch(
-                            searchEditText.text.toString()
-                        )
+                        if (searchEditText.text.isNotBlank()) {
+                            viewModel.getJoinGroupSearch(
+                                searchEditText.text.toString()
+                            )
+                        }
                         hideKeyboard(searchEditText)
                         return@setOnKeyListener true
                     }

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/plan/planlocation/PlanLocationFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/plan/planlocation/PlanLocationFragment.kt
@@ -35,47 +35,43 @@ class PlanLocationFragment :
     }
 
     private fun addListeners() {
-        binding.root.setOnClickListener {
-            requireContext().hideKeyboard(binding.etPlanLocationSearch)
-        }
-
-        binding.ivPlanLocationSearchBtn.setOnClickListener {
-            if (binding.etPlanLocationSearch.text.isNotBlank()) {
-                planLocationViewModel.getPlanLocationList(binding.etPlanLocationSearch.text.toString())
+        (binding.pingleSearchPlanLocation.editText).let { searchEditText ->
+            binding.root.setOnClickListener {
+                requireContext().hideKeyboard(searchEditText)
             }
-            requireContext().hideKeyboard(binding.etPlanLocationSearch)
-        }
 
-        binding.etPlanLocationSearch.setOnKeyListener(
-            View.OnKeyListener { _, keyCode, event ->
-                if (keyCode == KeyEvent.KEYCODE_ENTER && event.action == KeyEvent.ACTION_UP) {
-                    if (binding.etPlanLocationSearch.text.isNotBlank()) {
-                        planLocationViewModel.getPlanLocationList(binding.etPlanLocationSearch.text.toString())
+            searchEditText.setOnKeyListener(
+                View.OnKeyListener { _, keyCode, event ->
+                    if (keyCode == KeyEvent.KEYCODE_ENTER && event.action == KeyEvent.ACTION_UP) {
+                        if (searchEditText.text.isNotBlank()) {
+                            planLocationViewModel.getPlanLocationList(searchEditText.text.toString())
+                        }
+                        requireContext().hideKeyboard(searchEditText)
+                        return@OnKeyListener true
                     }
-                    requireContext().hideKeyboard(binding.etPlanLocationSearch)
-                    return@OnKeyListener true
+                    false
                 }
-                false
-            }
-        )
+            )
+        }
     }
 
     private fun collectData() {
-        planLocationViewModel.planLocationListState.flowWithLifecycle(viewLifecycleOwner.lifecycle).onEach { uiState ->
-            when (uiState) {
-                is UiState.Success -> {
-                    planLocationAdapter.submitList(uiState.data)
-                    binding.layoutPlanLocationEmpty.visibility = View.INVISIBLE
-                }
+        planLocationViewModel.planLocationListState.flowWithLifecycle(viewLifecycleOwner.lifecycle)
+            .onEach { uiState ->
+                when (uiState) {
+                    is UiState.Success -> {
+                        planLocationAdapter.submitList(uiState.data)
+                        binding.layoutPlanLocationEmpty.visibility = View.INVISIBLE
+                    }
 
-                is UiState.Empty -> {
-                    planLocationAdapter.submitList(null)
-                    binding.layoutPlanLocationEmpty.visibility = View.VISIBLE
-                }
+                    is UiState.Empty -> {
+                        planLocationAdapter.submitList(null)
+                        binding.layoutPlanLocationEmpty.visibility = View.VISIBLE
+                    }
 
-                else -> Unit
-            }
-        }.launchIn(viewLifecycleOwner.lifecycleScope)
+                    else -> Unit
+                }
+            }.launchIn(viewLifecycleOwner.lifecycleScope)
     }
 
     private fun deleteOldPosition(position: Int) {

--- a/app/src/main/res/layout/activity_join_group_search.xml
+++ b/app/src/main/res/layout/activity_join_group_search.xml
@@ -49,47 +49,15 @@
             app:layout_constraintStart_toEndOf="@id/gl_start"
             app:layout_constraintTop_toBottomOf="@id/include_join_group_search_topbar" />
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/layout_join_group_search"
+        <org.sopt.pingle.util.component.PingleSearch
+            android:id="@+id/pingle_search_join_group_search"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="24dp"
-            android:background="@drawable/shape_border_radius_8"
-            android:backgroundTint="@color/g_10"
-            app:layout_constraintEnd_toEndOf="@id/gl_end"
+            app:layout_constraintEnd_toStartOf="@id/gl_end"
             app:layout_constraintStart_toStartOf="@id/gl_start"
-            app:layout_constraintTop_toBottomOf="@id/tv_join_group_search_title">
-
-            <EditText
-                android:id="@+id/et_join_group_search"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="14dp"
-                android:layout_marginEnd="32dp"
-                android:background="@drawable/shape_border_radius_8"
-                android:hint="@string/join_group_search_hint"
-                android:inputType="text"
-                android:maxLength="100"
-                android:paddingVertical="@dimen/spacing12"
-                android:textAppearance="@style/TextAppearance.Pingle.Body.Semi.14"
-                android:textColor="@color/white"
-                android:textColorHint="@color/g_07"
-                android:textCursorDrawable="@drawable/shape_pingle_green_solid_width_1"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toStartOf="@id/iv_join_group_search_icon"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
-            <ImageView
-                android:id="@+id/iv_join_group_search_icon"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="14dp"
-                android:src="@drawable/ic_all_search_24"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
+            app:pingleSearchHint="@string/join_group_search_hint"
+            app:layout_constraintTop_toBottomOf="@id/tv_join_group_search_title" />
 
         <TextView
             android:id="@+id/tv_join_group_search_empty"
@@ -100,10 +68,10 @@
             android:textAppearance="@style/TextAppearance.Pingle.Sub.Semi.18"
             android:textColor="@color/g_06"
             android:visibility="invisible"
-            app:layout_constraintBottom_toBottomOf="@id/tv_join_group_search_create"
+            app:layout_constraintBottom_toBottomOf="@id/rv_join_group_search"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/layout_join_group_search" />
+            app:layout_constraintTop_toTopOf="@id/rv_join_group_search" />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rv_join_group_search"
@@ -115,7 +83,7 @@
             app:layout_constraintBottom_toTopOf="@id/tv_join_group_search_create"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/layout_join_group_search"
+            app:layout_constraintTop_toBottomOf="@id/pingle_search_join_group_search"
             tools:listitem="@layout/item_join_group_search" />
 
         <TextView

--- a/app/src/main/res/layout/fragment_plan_location.xml
+++ b/app/src/main/res/layout/fragment_plan_location.xml
@@ -23,47 +23,15 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/layout_plan_location_search"
+        <org.sopt.pingle.util.component.PingleSearch
+            android:id="@+id/pingle_search_plan_location"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="24dp"
-            android:background="@drawable/shape_border_radius_8"
-            android:backgroundTint="@color/g_10"
+            app:pingleSearchHint="@string/plan_location_hint"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_plan_location_title"
-            app:layout_constraintEnd_toEndOf="parent">
-
-            <EditText
-                android:id="@+id/et_plan_location_search"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="14dp"
-                android:layout_marginEnd="19dp"
-                android:backgroundTint="@android:color/transparent"
-                android:hint="@string/plan_location_hint"
-                android:inputType="text"
-                android:maxLines="1"
-                android:paddingVertical="@dimen/spacing12"
-                android:textAppearance="@style/TextAppearance.Pingle.Body.Semi.14"
-                android:textColor="@color/white"
-                android:textColorHint="@color/g_07"
-                android:textCursorDrawable="@drawable/shape_pingle_green_solid_width_1"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toStartOf="@id/iv_plan_location_search_btn"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
-            <ImageView
-                android:id="@+id/iv_plan_location_search_btn"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="14dp"
-                android:src="@drawable/ic_all_search_24"
-                app:layout_constraintBottom_toBottomOf="@id/et_plan_location_search"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="@id/et_plan_location_search" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
+            app:layout_constraintTop_toBottomOf="@id/tv_plan_location_title" />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rv_plan_location_list"
@@ -74,7 +42,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/layout_plan_location_search"
+            app:layout_constraintTop_toBottomOf="@id/pingle_search_plan_location"
             tools:listitem="@layout/item_plan_location" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
@@ -86,7 +54,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/layout_plan_location_search">
+            app:layout_constraintTop_toBottomOf="@id/pingle_search_plan_location">
 
             <TextView
                 android:id="@+id/tv_plan_location_empty"


### PR DESCRIPTION
## Related issue 🛠
- closed #191 

## Work Description ✏️
- 기존에 Search Bar가 사용되었던 뷰에 커스텀 Search Bar를 적용하였습니다. (기존 단체 입장 - 단체 검색 뷰, 핑글 개최 프로세스 - 장소 선택 뷰)

## Screenshot 📸
- 기존 단체 입장 - 단체 검색 뷰

https://github.com/TeamPINGLE/PINGLE-ANDROID/assets/103172971/d87706c9-a093-4536-8a35-242e8803af3c

- 핑글 개최 프로세스 - 장소 선택 뷰

https://github.com/TeamPINGLE/PINGLE-ANDROID/assets/103172971/6b45dec5-1f32-4ce2-96f3-4063310d5d3b


## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
- hideKeyboard 함수에 clearFocus 적용해둔 거 아직 머지 안 되어서 여기 영상엔 반영되지 않았습니당!