### PR TITLE
[mod] 지도 뷰 API 수정사항 반영

### DIFF
--- a/app/src/main/java/org/sopt/pingle/data/datasource/remote/MapRemoteDataSource.kt
+++ b/app/src/main/java/org/sopt/pingle/data/datasource/remote/MapRemoteDataSource.kt
@@ -7,7 +7,8 @@ import org.sopt.pingle.util.base.BaseResponse
 interface MapRemoteDataSource {
     suspend fun getPinListWithoutFiltering(
         teamId: Long,
-        category: String?
+        category: String?,
+        searchWord: String?
     ): BaseResponse<List<ResponsePinListDto>>
 
     suspend fun getPingleList(teamId: Long, pinId: Long, category: String?): BaseResponse<List<ResponsePingleListDto>>

--- a/app/src/main/java/org/sopt/pingle/data/datasourceimpl/remote/MapRemoteDataSourceImpl.kt
+++ b/app/src/main/java/org/sopt/pingle/data/datasourceimpl/remote/MapRemoteDataSourceImpl.kt
@@ -1,20 +1,25 @@
 package org.sopt.pingle.data.datasourceimpl.remote
 
-import javax.inject.Inject
 import org.sopt.pingle.data.datasource.remote.MapRemoteDataSource
 import org.sopt.pingle.data.model.remote.response.ResponsePinListDto
 import org.sopt.pingle.data.model.remote.response.ResponsePingleListDto
 import org.sopt.pingle.data.service.MapService
 import org.sopt.pingle.util.base.BaseResponse
+import javax.inject.Inject
 
 class MapRemoteDataSourceImpl @Inject constructor(
     private val mapService: MapService
 ) : MapRemoteDataSource {
     override suspend fun getPinListWithoutFiltering(
         teamId: Long,
-        category: String?
+        category: String?,
+        searchWord: String?
     ): BaseResponse<List<ResponsePinListDto>> =
-        mapService.getPinListWithoutFiltering(teamId = teamId, category = category)
+        mapService.getPinListWithoutFiltering(
+            teamId = teamId,
+            category = category,
+            searchWord = searchWord
+        )
 
     override suspend fun getPingleList(
         teamId: Long,

--- a/app/src/main/java/org/sopt/pingle/data/datasourceimpl/remote/MapRemoteDataSourceImpl.kt
+++ b/app/src/main/java/org/sopt/pingle/data/datasourceimpl/remote/MapRemoteDataSourceImpl.kt
@@ -1,11 +1,11 @@
 package org.sopt.pingle.data.datasourceimpl.remote
 
+import javax.inject.Inject
 import org.sopt.pingle.data.datasource.remote.MapRemoteDataSource
 import org.sopt.pingle.data.model.remote.response.ResponsePinListDto
 import org.sopt.pingle.data.model.remote.response.ResponsePingleListDto
 import org.sopt.pingle.data.service.MapService
 import org.sopt.pingle.util.base.BaseResponse
-import javax.inject.Inject
 
 class MapRemoteDataSourceImpl @Inject constructor(
     private val mapService: MapService

--- a/app/src/main/java/org/sopt/pingle/data/model/remote/response/ResponsePinListDto.kt
+++ b/app/src/main/java/org/sopt/pingle/data/model/remote/response/ResponsePinListDto.kt
@@ -13,15 +13,12 @@ data class ResponsePinListDto(
     @SerialName("y")
     val y: Double,
     @SerialName("category")
-    val category: String,
-    @SerialName("meetingCount")
-    val meetingCount: Int
+    val category: String
 ) {
     fun toPinEntity() = PinEntity(
         id = this.id,
         x = this.x,
         y = this.y,
-        category = this.category,
-        meetingCount = this.meetingCount
+        category = this.category
     )
 }

--- a/app/src/main/java/org/sopt/pingle/data/repository/MapRepositoryImpl.kt
+++ b/app/src/main/java/org/sopt/pingle/data/repository/MapRepositoryImpl.kt
@@ -13,12 +13,14 @@ class MapRepositoryImpl @Inject constructor(
 ) : MapRepository {
     override suspend fun getPinListWithoutFiltering(
         teamId: Long,
-        category: String?
+        category: String?,
+        searchWord: String?
     ): Flow<List<PinEntity>> = flow {
         val result = runCatching {
             mapRemoteDataSource.getPinListWithoutFiltering(
                 teamId = teamId,
-                category = category
+                category = category,
+                searchWord = searchWord
             ).data.map { pin ->
                 pin.toPinEntity()
             }

--- a/app/src/main/java/org/sopt/pingle/data/service/MapService.kt
+++ b/app/src/main/java/org/sopt/pingle/data/service/MapService.kt
@@ -29,7 +29,7 @@ interface MapService {
         const val PINS = "pins"
         const val PIN_ID = "pinId"
         const val CATEGORY = "category"
-        const val SEARCH_WORD= "q"
+        const val SEARCH_WORD = "q"
         const val MEETINGS = "meetings"
     }
 }

--- a/app/src/main/java/org/sopt/pingle/data/service/MapService.kt
+++ b/app/src/main/java/org/sopt/pingle/data/service/MapService.kt
@@ -11,7 +11,8 @@ interface MapService {
     @GET("$VERSION/$TEAMS/{$TEAM_ID}/$PINS")
     suspend fun getPinListWithoutFiltering(
         @Path("$TEAM_ID") teamId: Long,
-        @Query(CATEGORY) category: String?
+        @Query(CATEGORY) category: String?,
+        @Query(SEARCH_WORD) searchWord: String?
     ): BaseResponse<List<ResponsePinListDto>>
 
     @GET("$VERSION/$TEAMS/{$TEAM_ID}/$PINS/{$PIN_ID}/$MEETINGS")
@@ -28,6 +29,7 @@ interface MapService {
         const val PINS = "pins"
         const val PIN_ID = "pinId"
         const val CATEGORY = "category"
+        const val SEARCH_WORD= "q"
         const val MEETINGS = "meetings"
     }
 }

--- a/app/src/main/java/org/sopt/pingle/domain/model/PinEntity.kt
+++ b/app/src/main/java/org/sopt/pingle/domain/model/PinEntity.kt
@@ -4,6 +4,5 @@ data class PinEntity(
     val id: Long,
     val x: Double,
     val y: Double,
-    val category: String,
-    val meetingCount: Int
+    val category: String
 )

--- a/app/src/main/java/org/sopt/pingle/domain/repository/MapRepository.kt
+++ b/app/src/main/java/org/sopt/pingle/domain/repository/MapRepository.kt
@@ -5,6 +5,6 @@ import org.sopt.pingle.domain.model.PinEntity
 import org.sopt.pingle.domain.model.PingleEntity
 
 interface MapRepository {
-    suspend fun getPinListWithoutFiltering(teamId: Long, category: String?): Flow<List<PinEntity>>
+    suspend fun getPinListWithoutFiltering(teamId: Long, category: String?, searchWord: String?): Flow<List<PinEntity>>
     suspend fun getPingleList(teamId: Long, pinId: Long, category: String?): Flow<List<PingleEntity>>
 }

--- a/app/src/main/java/org/sopt/pingle/domain/usecase/GetPinListWithoutFilteringUseCase.kt
+++ b/app/src/main/java/org/sopt/pingle/domain/usecase/GetPinListWithoutFilteringUseCase.kt
@@ -7,6 +7,14 @@ import org.sopt.pingle.domain.repository.MapRepository
 class GetPinListWithoutFilteringUseCase(
     private val mapRepository: MapRepository
 ) {
-    suspend operator fun invoke(teamId: Long, category: String?): Flow<List<PinEntity>> =
-        mapRepository.getPinListWithoutFiltering(teamId = teamId, category = category)
+    suspend operator fun invoke(
+        teamId: Long,
+        category: String?,
+        searchWord: String?
+    ): Flow<List<PinEntity>> =
+        mapRepository.getPinListWithoutFiltering(
+            teamId = teamId,
+            category = category,
+            searchWord = searchWord
+        )
 }

--- a/app/src/main/java/org/sopt/pingle/presentation/model/SearchModel.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/model/SearchModel.kt
@@ -7,5 +7,5 @@ import org.sopt.pingle.presentation.type.HomeViewType
 @Parcelize
 data class SearchModel(
     val homeViewType: HomeViewType,
-    val searchWord: String
+    val searchWord: String?
 ) : Parcelable

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/HomeFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/HomeFragment.kt
@@ -121,7 +121,7 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
                 with(binding) {
                     pingleSearchHomeSearch.binding.etSearchPingleEditText.setText(homeViewModel.searchWord.value)
 
-                    (searchWord.isNotBlank()).let { isSearching ->
+                    (!searchWord.isNullOrBlank()).let { isSearching ->
                         pingleSearchHomeSearch.visibility =
                             if (isSearching) View.VISIBLE else View.INVISIBLE
                         tvHomeGroup.visibility = if (isSearching) View.INVISIBLE else View.VISIBLE
@@ -168,7 +168,7 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
 
     private fun setStopSearchCallback() {
         stopSearchCallback =
-            object : OnBackPressedCallback(homeViewModel.searchWord.value.isNotBlank()) {
+            object : OnBackPressedCallback(!homeViewModel.searchWord.value.isNullOrEmpty()) {
                 override fun handleOnBackPressed() {
                     homeViewModel.clearSearchWord()
                     navigateToSearch()

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/HomeFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/HomeFragment.kt
@@ -103,12 +103,6 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
     }
 
     private fun collectData() {
-        homeViewModel.category.flowWithLifecycle(viewLifecycleOwner.lifecycle)
-            .distinctUntilChanged()
-            .onEach {
-                homeViewModel.getPinListWithoutFilter()
-            }.launchIn(viewLifecycleOwner.lifecycleScope)
-
         homeViewModel.homeViewType.flowWithLifecycle(viewLifecycleOwner.lifecycle).onEach {
             with(binding) {
                 vpHome.setCurrentItem(homeViewModel.homeViewType.value.index, false)
@@ -119,7 +113,6 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
         homeViewModel.searchWord.flowWithLifecycle(viewLifecycleOwner.lifecycle)
             .onEach { searchWord ->
                 with(binding) {
-                    homeViewModel.getPinListWithoutFilter()
                     pingleSearchHomeSearch.binding.etSearchPingleEditText.setText(homeViewModel.searchWord.value)
 
                     (!searchWord.isNullOrBlank()).let { isSearching ->

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/HomeFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/HomeFragment.kt
@@ -12,7 +12,6 @@ import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.sopt.pingle.R

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/HomeFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/HomeFragment.kt
@@ -119,6 +119,7 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
         homeViewModel.searchWord.flowWithLifecycle(viewLifecycleOwner.lifecycle)
             .onEach { searchWord ->
                 with(binding) {
+                    homeViewModel.getPinListWithoutFilter()
                     pingleSearchHomeSearch.binding.etSearchPingleEditText.setText(homeViewModel.searchWord.value)
 
                     (!searchWord.isNullOrBlank()).let { isSearching ->
@@ -160,7 +161,7 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
             registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { activityResult ->
                 if (activityResult.resultCode == RESULT_OK) {
                     homeViewModel.setSearchWord(
-                        activityResult.data?.getStringExtra(SEARCH_WORD) ?: ""
+                        activityResult.data?.getStringExtra(SEARCH_WORD)
                     )
                 }
             }

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/HomeViewModel.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/HomeViewModel.kt
@@ -74,7 +74,7 @@ class HomeViewModel @Inject constructor(
         _homeViewType.value = homeViewType
     }
 
-    fun setSearchWord(searchWord: String) {
+    fun setSearchWord(searchWord: String?) {
         _searchWord.value = searchWord
     }
 

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/HomeViewModel.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/HomeViewModel.kt
@@ -38,7 +38,7 @@ class HomeViewModel @Inject constructor(
     private val _homeViewType = MutableStateFlow<HomeViewType>(HomeViewType.MAP)
     val homeViewType get() = _homeViewType.asStateFlow()
 
-    private var _searchWord = MutableStateFlow("")
+    private var _searchWord = MutableStateFlow<String?>(null)
     val searchWord get() = _searchWord.asStateFlow()
 
     private val _pinEntityListState = MutableStateFlow<UiState<List<PinEntity>>>(UiState.Empty)
@@ -79,7 +79,7 @@ class HomeViewModel @Inject constructor(
     }
 
     fun clearSearchWord() {
-        _searchWord.value = ""
+        _searchWord.value = null
     }
 
     private fun setMarkerModelListIsSelected(position: Int) {
@@ -140,7 +140,8 @@ class HomeViewModel @Inject constructor(
             runCatching {
                 getPinListWithoutFilteringUseCase(
                     teamId = localStorage.groupId.toLong(),
-                    category = category.value?.name
+                    category = category.value?.name,
+                    searchWord = searchWord.value
                 ).collect() { pinList ->
                     _pinEntityListState.value = UiState.Success(pinList)
                 }

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/mainlist/MainListFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/mainlist/MainListFragment.kt
@@ -103,7 +103,7 @@ class MainListFragment : BindingFragment<FragmentMainListBinding>(R.layout.fragm
     private fun collectData() {
         homeViewModel.searchWord.flowWithLifecycle(viewLifecycleOwner.lifecycle)
             .onEach { searchWord ->
-                (searchWord.isNotBlank()).let { isSearching ->
+                (!searchWord.isNullOrBlank()).let { isSearching ->
                     with(binding.tvMainListSearchCount) {
                         visibility = if (isSearching) View.VISIBLE else View.INVISIBLE
                         text = getString(

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/map/MapFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/map/MapFragment.kt
@@ -171,11 +171,24 @@ class MapFragment : BindingFragment<FragmentMapBinding>(R.layout.fragment_map), 
     }
 
     private fun collectData() {
+        homeViewModel.category.flowWithLifecycle(viewLifecycleOwner.lifecycle)
+            .distinctUntilChanged()
+            .onEach {
+                homeViewModel.getPinListWithoutFilter()
+            }.launchIn(viewLifecycleOwner.lifecycleScope)
+
+
+        homeViewModel.searchWord.flowWithLifecycle(viewLifecycleOwner.lifecycle)
+            .onEach { searchWord ->
+                homeViewModel.getPinListWithoutFilter()
+            }.launchIn(viewLifecycleOwner.lifecycleScope)
+
         homeViewModel.markerModelData.flowWithLifecycle(viewLifecycleOwner.lifecycle)
             .onEach { markerModelData ->
                 (markerModelData.first == DEFAULT_SELECTED_MARKER_POSITION).let { isMarkerUnselected ->
                     with(binding) {
-                        fabMapHere.visibility = if (isMarkerUnselected) View.VISIBLE else View.INVISIBLE
+                        fabMapHere.visibility =
+                            if (isMarkerUnselected) View.VISIBLE else View.INVISIBLE
                     }
                 }
             }.launchIn(viewLifecycleOwner.lifecycleScope)
@@ -241,11 +254,11 @@ class MapFragment : BindingFragment<FragmentMapBinding>(R.layout.fragment_map), 
 
     private fun setLocationTrackingMode() {
         if (LOCATION_PERMISSIONS.any { permission ->
-            ContextCompat.checkSelfPermission(
+                ContextCompat.checkSelfPermission(
                     requireContext(),
                     permission
                 ) == PackageManager.PERMISSION_GRANTED
-        }
+            }
         ) {
             locationSource = FusedLocationSource(this, LOCATION_PERMISSION_REQUEST_CODE)
 

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/map/MapFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/map/MapFragment.kt
@@ -252,11 +252,11 @@ class MapFragment : BindingFragment<FragmentMapBinding>(R.layout.fragment_map), 
 
     private fun setLocationTrackingMode() {
         if (LOCATION_PERMISSIONS.any { permission ->
-                ContextCompat.checkSelfPermission(
+            ContextCompat.checkSelfPermission(
                     requireContext(),
                     permission
                 ) == PackageManager.PERMISSION_GRANTED
-            }
+        }
         ) {
             locationSource = FusedLocationSource(this, LOCATION_PERMISSION_REQUEST_CODE)
 

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/map/MapFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/map/MapFragment.kt
@@ -177,7 +177,6 @@ class MapFragment : BindingFragment<FragmentMapBinding>(R.layout.fragment_map), 
                 homeViewModel.getPinListWithoutFilter()
             }.launchIn(viewLifecycleOwner.lifecycleScope)
 
-
         homeViewModel.searchWord.flowWithLifecycle(viewLifecycleOwner.lifecycle)
             .onEach { searchWord ->
                 homeViewModel.getPinListWithoutFilter()
@@ -254,11 +253,11 @@ class MapFragment : BindingFragment<FragmentMapBinding>(R.layout.fragment_map), 
 
     private fun setLocationTrackingMode() {
         if (LOCATION_PERMISSIONS.any { permission ->
-                ContextCompat.checkSelfPermission(
+            ContextCompat.checkSelfPermission(
                     requireContext(),
                     permission
                 ) == PackageManager.PERMISSION_GRANTED
-            }
+        }
         ) {
             locationSource = FusedLocationSource(this, LOCATION_PERMISSION_REQUEST_CODE)
 

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/search/SearchActivity.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/search/SearchActivity.kt
@@ -53,7 +53,7 @@ class SearchActivity : BindingActivity<ActivitySearchBinding>(R.layout.activity_
             }
 
             binding.pingleSearchSearch.binding.etSearchPingleEditText.run {
-                if (searchModel.searchWord.isNotBlank()) setText(searchModel.searchWord)
+                if (!searchModel.searchWord.isNullOrBlank()) setText(searchModel.searchWord)
             }
         }
 


### PR DESCRIPTION
## Related issue 🛠
- closed #208 

## Work Description ✏️
- 3차 스프린트 때 수정된 지도 뷰의 API 수정사항을 반영하였습니다.
    - 핀 목록 (좌표 필터링 X) API에 검색어 파라미터 추가
    -  핀 목록 (좌표 필터링 X) API에 meetingCount 제거
    - 지도 뷰 검색 기능 구현

## Screenshot 📸
https://github.com/TeamPINGLE/PINGLE-ANDROID/assets/103172971/bb3cdd05-37af-45cc-9456-ddec3b5899f6

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
- 플로우 1도 모르면서 플로우 쓰는 중이라는 걸 다시 한 번 깨달으며,, 플로우 스터디 할 사람 구합니다 ㅋㅋ
- 로직 정리 좀 하려고 했는데 아직 리스트뷰 API 연동이 안 된 상태라 ㅋㅋ ㅠ 전체적인 로직 정리는 리스트뷰 API 연동하면서 하겠습니다...
- 화면 전환은 빠르게 되는데 서버 통신이 느려서 발생하는 딜레이가 넘 신경 쓰이네요,, 로직 수정하면 좀 나아지려나요 ㅋㅋ ㅠ 다음 스프린트 때라도 로딩 뷰를 만들자고 하는 게 나으려나욤,,, 의견 plz ㅋㅋ ㅠ
- ` distinctUntilChanged()` 관련해서 피드백 받았던 거 이번에 수정하려 했더니 죽어도 안 되네요 ㅠ 도와주세요,,