### PR TITLE
[fix] SearchPingle에 텍스트 입력 시 focus가 사라지는 문제 해결

### DIFF
--- a/app/src/main/java/org/sopt/pingle/util/component/PingleSearch.kt
+++ b/app/src/main/java/org/sopt/pingle/util/component/PingleSearch.kt
@@ -37,6 +37,7 @@ class PingleSearch @JvmOverloads constructor(
             }
 
             etSearchPingleEditText.doAfterTextChanged { text ->
+                if (!etSearchPingleEditText.hasFocus()) etSearchPingleEditText.requestFocus()
                 _binding.ivSearchPingleSearch.visibility =
                     if (text.isNullOrEmpty()) View.VISIBLE else View.GONE
                 _binding.ivSearchPingleClear.visibility =


### PR DESCRIPTION
## Related issue 🛠
- closed #230 

## Work Description ✏️
- SearchPingle에 텍스트 입력 시 focus가 사라지는 문제를 해결하였습니다.
## Screenshot 📸
**핑글 개최 프로세스**

https://github.com/TeamPINGLE/PINGLE-ANDROID/assets/103172971/b1a8b989-d2d4-40b2-a17e-8ac6858cc871

**단체 가입**

https://github.com/TeamPINGLE/PINGLE-ANDROID/assets/103172971/83ba4078-de7b-4d17-bc45-90bb9deeb742

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
- 서치 뷰 제외하고 다른 뷰에에서 서치바 클릭 시 다시 클릭해야 검색이 진행 되었던 게 텍스트 입력하자마자 포커스가 사라져서 발생하는 문제더라구요,, 근데 왜 그러는지는 아직 이유를 못 찾았고,, 입력이 발생 -> 포커스 있는지 확인 -> 포커스 없으면 포커스 주는 방식으로 해결했어요
- 서치 뷰에서는 왜 잘 된 거였냐면,,! 서치 뷰는 진입하자마자 키보드 올라오게 해달라고 해서 initLayout에서 포커스를 줬기 때문에 잘 된 것 같슴다 !!