### PR TITLE
[fix] 3차 스프린트 QA 수정사항 반영

### DIFF
--- a/app/src/main/java/org/sopt/pingle/data/datasource/local/PingleLocalDataSource.kt
+++ b/app/src/main/java/org/sopt/pingle/data/datasource/local/PingleLocalDataSource.kt
@@ -1,6 +1,9 @@
 package org.sopt.pingle.data.datasource.local
 
+import android.content.SharedPreferences
+
 interface PingleLocalDataSource {
+    val sharedPreference: SharedPreferences
     var isLogin: Boolean
     var userName: String
     var accessToken: String

--- a/app/src/main/java/org/sopt/pingle/data/datasourceimpl/local/PingleLocalDataSourceImpl.kt
+++ b/app/src/main/java/org/sopt/pingle/data/datasourceimpl/local/PingleLocalDataSourceImpl.kt
@@ -31,6 +31,9 @@ class PingleLocalDataSourceImpl @Inject constructor(
             )
         }
 
+    override val sharedPreference: SharedPreferences
+        get() = pref
+
     override var isLogin: Boolean
         get() = pref.getBoolean(AUTO_LOGIN, false)
         set(value) = pref.edit { putBoolean(AUTO_LOGIN, value) }

--- a/app/src/main/java/org/sopt/pingle/presentation/model/PingleFilterModel.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/model/PingleFilterModel.kt
@@ -1,0 +1,12 @@
+package org.sopt.pingle.presentation.model
+
+import org.sopt.pingle.presentation.type.CategoryType
+import org.sopt.pingle.presentation.type.HomeViewType
+import org.sopt.pingle.presentation.type.MainListOrderType
+
+data class PingleFilterModel (
+    val category: CategoryType? = null,
+    val searchWord: String? = null,
+    val mainListOrderType: MainListOrderType = MainListOrderType.NEW,
+    val homeViewType: HomeViewType = HomeViewType.MAP
+)

--- a/app/src/main/java/org/sopt/pingle/presentation/model/PingleFilterModel.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/model/PingleFilterModel.kt
@@ -4,7 +4,7 @@ import org.sopt.pingle.presentation.type.CategoryType
 import org.sopt.pingle.presentation.type.HomeViewType
 import org.sopt.pingle.presentation.type.MainListOrderType
 
-data class PingleFilterModel (
+data class PingleFilterModel(
     val category: CategoryType? = null,
     val searchWord: String? = null,
     val mainListOrderType: MainListOrderType = MainListOrderType.NEW,

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/auth/AuthActivity.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/auth/AuthActivity.kt
@@ -13,8 +13,11 @@ import org.sopt.pingle.R
 import org.sopt.pingle.data.service.KakaoAuthService
 import org.sopt.pingle.databinding.ActivityAuthBinding
 import org.sopt.pingle.presentation.ui.main.MainActivity
+import org.sopt.pingle.presentation.ui.main.more.MoreFragment.Companion.MORE_FRAGMENT
 import org.sopt.pingle.presentation.ui.onboarding.onboarding.OnboardingActivity
+import org.sopt.pingle.presentation.ui.onboarding.onboarding.OnboardingActivity.Companion.FROM_ACTIVITY
 import org.sopt.pingle.util.AmplitudeUtils
+import org.sopt.pingle.util.activity.setDoubleBackPressToExit
 import org.sopt.pingle.util.base.BindingActivity
 import org.sopt.pingle.util.view.UiState
 import timber.log.Timber
@@ -28,8 +31,16 @@ class AuthActivity : BindingActivity<ActivityAuthBinding>(R.layout.activity_auth
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        initLayout()
         addListeners()
         collectData()
+    }
+
+    private fun initLayout() {
+        when (intent.getStringExtra(FROM_ACTIVITY)) {
+            MORE_FRAGMENT -> setDoubleBackPressToExit(binding.root)
+            else -> Unit
+        }
     }
 
     private fun addListeners() {

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/HomeFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/HomeFragment.kt
@@ -3,6 +3,7 @@ package org.sopt.pingle.presentation.ui.main.home
 import android.app.Activity.RESULT_OK
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.ActivityResultLauncher
@@ -12,9 +13,9 @@ import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import org.sopt.pingle.R
 import org.sopt.pingle.databinding.FragmentHomeBinding
@@ -89,7 +90,7 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
             ivHomeSearch.setOnClickListener {
                 navigateToSearch()
 
-                when (homeViewModel.homeViewType.value) {
+                when (homeViewModel.pingleFilter.value.homeViewType) {
                     HomeViewType.MAP -> AmplitudeUtils.trackEvent(CLICK_SEARCH_MAP)
                     HomeViewType.MAIN_LIST -> AmplitudeUtils.trackEvent(CLICK_SEARCH_LIST)
                 }
@@ -104,7 +105,7 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
                 checkedIds.getOrNull(SINGLE_SELECTION)
                     ?.let {
                         group.findViewById<PingleChip>(it).categoryType.let { categoryType ->
-                            when (homeViewModel.homeViewType.value) {
+                            when (homeViewModel.pingleFilter.value.homeViewType) {
                                 HomeViewType.MAP -> AmplitudeUtils.trackEventWithProperty(
                                     eventName = CLICK_CATEGORY_MAP,
                                     propertyName = CATEGORY,
@@ -123,7 +124,7 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
 
             fabHomeChange.setOnClickListener {
                 with(homeViewModel) {
-                    when (homeViewType.value) {
+                    when (pingleFilter.value.homeViewType) {
                         HomeViewType.MAP -> {
                             AmplitudeUtils.trackEvent(CLICK_LIST_MAP)
                             setHomeViewType(HomeViewType.MAIN_LIST)
@@ -140,32 +141,34 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
     }
 
     private fun collectData() {
-        combine(
-            homeViewModel.category.flowWithLifecycle(viewLifecycleOwner.lifecycle).distinctUntilChanged(),
-            homeViewModel.searchWord.flowWithLifecycle(viewLifecycleOwner.lifecycle).distinctUntilChanged(),
-            homeViewModel.mainListOrderType.flowWithLifecycle(viewLifecycleOwner.lifecycle).distinctUntilChanged(),
-            homeViewModel.homeViewType.flowWithLifecycle(viewLifecycleOwner.lifecycle).distinctUntilChanged()
-        ) { _, searchWord, _, homeViewType ->
-            Pair(searchWord != homeViewModel.lastSearchWord, homeViewType)
-        }.onEach { searchStatusAndHomeViewType ->
-            when (searchStatusAndHomeViewType.second) {
-                HomeViewType.MAIN_LIST -> homeViewModel.getMainListPingleList()
-                HomeViewType.MAP -> homeViewModel.getPinListWithoutFilter(isSearching = searchStatusAndHomeViewType.first)
-            }
-            homeViewModel.setLastSearchWord(homeViewModel.searchWord.value)
-        }.launchIn(viewLifecycleOwner.lifecycleScope)
+        homeViewModel.pingleFilter.flowWithLifecycle(viewLifecycleOwner.lifecycle)
+            .distinctUntilChanged()
+            .onEach { pingleFilter ->
+                Log.e("ㅋㅋ", pingleFilter.toString())
+                with(pingleFilter) {
+                    when (homeViewType) {
+                        HomeViewType.MAIN_LIST -> homeViewModel.getMainListPingleList()
+                        HomeViewType.MAP -> homeViewModel.getPinListWithoutFilter(isSearching = searchWord != homeViewModel.lastSearchWord)
+                    }
+                    homeViewModel.setLastSearchWord(searchWord)
+                }
+            }.launchIn(viewLifecycleOwner.lifecycleScope)
 
-        homeViewModel.homeViewType.flowWithLifecycle(viewLifecycleOwner.lifecycle).onEach {
-            with(binding) {
-                vpHome.setCurrentItem(homeViewModel.homeViewType.value.index, false)
-                fabHomeChange.setImageResource(homeViewModel.homeViewType.value.fabDrawableRes)
-            }
-        }.launchIn(viewLifecycleOwner.lifecycleScope)
+        homeViewModel.pingleFilter.map { pingleFilter -> pingleFilter.homeViewType }
+            .distinctUntilChanged()
+            .flowWithLifecycle(viewLifecycleOwner.lifecycle).onEach { homeViewType ->
+                with(binding) {
+                    vpHome.setCurrentItem(homeViewType.index, false)
+                    fabHomeChange.setImageResource(homeViewType.fabDrawableRes)
+                }
+            }.launchIn(viewLifecycleOwner.lifecycleScope)
 
-        homeViewModel.searchWord.flowWithLifecycle(viewLifecycleOwner.lifecycle)
+        homeViewModel.pingleFilter.map { pingleFilter -> pingleFilter.searchWord }
+            .distinctUntilChanged()
+            .flowWithLifecycle(viewLifecycleOwner.lifecycle)
             .onEach { searchWord ->
                 with(binding) {
-                    pingleSearchHomeSearch.binding.etSearchPingleEditText.setText(homeViewModel.searchWord.value)
+                    pingleSearchHomeSearch.binding.etSearchPingleEditText.setText(searchWord)
 
                     (!searchWord.isNullOrEmpty()).let { isSearching ->
                         pingleSearchHomeSearch.visibility =
@@ -209,7 +212,6 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
         resultLauncher =
             registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { activityResult ->
                 if (activityResult.resultCode == RESULT_OK) {
-                    homeViewModel.clearCategory()
                     homeViewModel.setSearchWord(
                         activityResult.data?.getStringExtra(SEARCH_WORD)
                     )
@@ -222,7 +224,7 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
             this.viewLifecycleOwner,
             object : OnBackPressedCallback(true) {
                 override fun handleOnBackPressed() {
-                    if (homeViewModel.searchWord.value.isNullOrEmpty()) {
+                    if (homeViewModel.pingleFilter.value.searchWord.isNullOrEmpty()) {
                         if (System.currentTimeMillis() - backPressedTime <= FINISH_INTERVAL_TIME) {
                             requireActivity().finish()
                         } else {
@@ -245,7 +247,7 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
 
     private fun initChip() {
         with(binding) {
-            homeViewModel.category.value.let { selectedCategory ->
+            homeViewModel.pingleFilter.value.category.let { selectedCategory ->
                 chipHomeCategoryPlay.isChecked = selectedCategory == CategoryType.PLAY
                 chipHomeCategoryStudy.isChecked = selectedCategory == CategoryType.STUDY
                 chipHomeCategoryMulti.isChecked = selectedCategory == CategoryType.MULTI
@@ -256,13 +258,15 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
 
     private fun navigateToSearch() {
         Intent(requireContext(), SearchActivity::class.java).apply {
-            putExtra(
-                SEARCH_MODEL,
-                SearchModel(
-                    homeViewType = homeViewModel.homeViewType.value,
-                    searchWord = homeViewModel.searchWord.value
+            with(homeViewModel.pingleFilter.value) {
+                putExtra(
+                    SEARCH_MODEL,
+                    SearchModel(
+                        homeViewType = homeViewType,
+                        searchWord = searchWord
+                    )
                 )
-            )
+            }
             resultLauncher.launch(this)
         }
     }

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/HomeFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/HomeFragment.kt
@@ -145,13 +145,14 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
             homeViewModel.searchWord.flowWithLifecycle(viewLifecycleOwner.lifecycle).distinctUntilChanged(),
             homeViewModel.mainListOrderType.flowWithLifecycle(viewLifecycleOwner.lifecycle).distinctUntilChanged(),
             homeViewModel.homeViewType.flowWithLifecycle(viewLifecycleOwner.lifecycle).distinctUntilChanged()
-        ) { _, _, _, homeViewType ->
-            homeViewType
-        }.onEach { homeViewType ->
-            when (homeViewType) {
+        ) { _, searchWord, _, homeViewType ->
+            Pair(searchWord != homeViewModel.lastSearchWord, homeViewType)
+        }.onEach { searchStatusAndHomeViewType ->
+            when (searchStatusAndHomeViewType.second) {
                 HomeViewType.MAIN_LIST -> homeViewModel.getMainListPingleList()
-                HomeViewType.MAP -> homeViewModel.getPinListWithoutFilter()
+                HomeViewType.MAP -> homeViewModel.getPinListWithoutFilter(isSearching = searchStatusAndHomeViewType.first)
             }
+            homeViewModel.setLastSearchWord(homeViewModel.searchWord.value)
         }.launchIn(viewLifecycleOwner.lifecycleScope)
 
         homeViewModel.homeViewType.flowWithLifecycle(viewLifecycleOwner.lifecycle).onEach {

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/HomeFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/HomeFragment.kt
@@ -3,7 +3,6 @@ package org.sopt.pingle.presentation.ui.main.home
 import android.app.Activity.RESULT_OK
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.ActivityResultLauncher
@@ -144,7 +143,6 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
         homeViewModel.pingleFilter.flowWithLifecycle(viewLifecycleOwner.lifecycle)
             .distinctUntilChanged()
             .onEach { pingleFilter ->
-                Log.e("ㅋㅋ", pingleFilter.toString())
                 with(pingleFilter) {
                     when (homeViewType) {
                         HomeViewType.MAIN_LIST -> homeViewModel.getMainListPingleList()

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/HomeViewModel.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/HomeViewModel.kt
@@ -45,7 +45,7 @@ class HomeViewModel @Inject constructor(
     private val sharedPreferenceChangeListener =
         SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
             if (key == GROUP_ID) {
-                clearPingleFiler()
+                clearPingleFilter()
                 clearMarkerModelData()
                 clearSelectedMarkerPosition()
             }
@@ -96,7 +96,7 @@ class HomeViewModel @Inject constructor(
     private val _mainListPingleListState = MutableSharedFlow<UiState<List<MainListPingleModel>>>()
     val mainListPingleListState get() = _mainListPingleListState.asSharedFlow()
 
-    private fun clearPingleFiler() {
+    private fun clearPingleFilter() {
         _pingleFilter.value = PingleFilterModel()
     }
 

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/HomeViewModel.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/HomeViewModel.kt
@@ -1,5 +1,6 @@
 package org.sopt.pingle.presentation.ui.main.home
 
+import android.content.SharedPreferences
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -39,6 +40,26 @@ class HomeViewModel @Inject constructor(
     private val getPinListWithoutFilteringUseCase: GetPinListWithoutFilteringUseCase,
     private val postPingleJoinUseCase: PostPingleJoinUseCase
 ) : ViewModel() {
+    private val sharedPreferenceChangeListener =
+        SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+            if (key == GROUP_ID) {
+                setHomeViewType(HomeViewType.MAP)
+                clearCategory()
+                clearSearchWord()
+                clearMarkerModelData()
+                clearSelectedMarkerPosition()
+            }
+        }
+
+    init {
+        localStorage.sharedPreference.registerOnSharedPreferenceChangeListener(sharedPreferenceChangeListener)
+    }
+
+    override fun onCleared() {
+        localStorage.sharedPreference.unregisterOnSharedPreferenceChangeListener(sharedPreferenceChangeListener)
+        super.onCleared()
+    }
+
     private val _category = MutableStateFlow<CategoryType?>(null)
     val category get() = _category.asStateFlow()
 
@@ -277,6 +298,7 @@ class HomeViewModel @Inject constructor(
     }
 
     companion object {
+        private const val GROUP_ID = "GroupId"
         const val DEFAULT_SELECTED_MARKER_POSITION = -1
     }
 }

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/HomeViewModel.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/HomeViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import org.sopt.pingle.data.datasource.local.PingleLocalDataSource
@@ -23,6 +24,7 @@ import org.sopt.pingle.domain.usecase.PostPingleJoinUseCase
 import org.sopt.pingle.presentation.mapper.toMainListPingleModel
 import org.sopt.pingle.presentation.model.MainListPingleModel
 import org.sopt.pingle.presentation.model.MarkerModel
+import org.sopt.pingle.presentation.model.PingleFilterModel
 import org.sopt.pingle.presentation.type.CategoryType
 import org.sopt.pingle.presentation.type.HomeViewType
 import org.sopt.pingle.presentation.type.MainListOrderType
@@ -43,9 +45,7 @@ class HomeViewModel @Inject constructor(
     private val sharedPreferenceChangeListener =
         SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
             if (key == GROUP_ID) {
-                setHomeViewType(HomeViewType.MAP)
-                clearCategory()
-                clearSearchWord()
+                clearPingleFiler()
                 clearMarkerModelData()
                 clearSelectedMarkerPosition()
             }
@@ -64,14 +64,8 @@ class HomeViewModel @Inject constructor(
         super.onCleared()
     }
 
-    private val _category = MutableStateFlow<CategoryType?>(null)
-    val category get() = _category.asStateFlow()
-
-    private val _homeViewType = MutableStateFlow<HomeViewType>(HomeViewType.MAP)
-    val homeViewType get() = _homeViewType.asStateFlow()
-
-    private var _searchWord = MutableStateFlow<String?>(null)
-    val searchWord get() = _searchWord.asStateFlow()
+    private var _pingleFilter = MutableStateFlow<PingleFilterModel>(PingleFilterModel())
+    val pingleFilter get() = _pingleFilter.asStateFlow()
 
     private var _lastSearchWord: String? = null
     val lastSearchWord get() = _lastSearchWord
@@ -99,31 +93,42 @@ class HomeViewModel @Inject constructor(
     private val _pingleDeleteState = MutableSharedFlow<UiState<Unit?>>()
     val pingleDeleteState get() = _pingleDeleteState.asSharedFlow()
 
-    private val _mainListOrderType = MutableStateFlow(MainListOrderType.NEW)
-    val mainListOrderType get() = _mainListOrderType.asStateFlow()
-
     private val _mainListPingleListState = MutableSharedFlow<UiState<List<MainListPingleModel>>>()
     val mainListPingleListState get() = _mainListPingleListState.asSharedFlow()
 
-    fun setCategory(category: CategoryType?) {
-        _category.value = category
+    private fun clearPingleFiler() {
+        _pingleFilter.value = PingleFilterModel()
     }
 
-    fun clearCategory() {
-        _category.value = null
+    fun setCategory(category: CategoryType?) {
+        _pingleFilter.update { pingleFilter ->
+            pingleFilter.copy(category = category)
+        }
     }
 
     fun setHomeViewType(homeViewType: HomeViewType) {
-        _homeViewType.value = homeViewType
+        _pingleFilter.update { pingleFilter ->
+            pingleFilter.copy(homeViewType = homeViewType)
+        }
     }
 
     fun setSearchWord(searchWord: String?) {
-        _searchWord.value = searchWord
+        _pingleFilter.update { pingleFilter ->
+            pingleFilter.copy(category = null, searchWord = searchWord)
+        }
     }
 
     fun clearSearchWord() {
-        _searchWord.value = null
+        _pingleFilter.update { pingleFilter ->
+            pingleFilter.copy(searchWord = null)
+        }
         _lastSearchWord = null
+    }
+
+    fun setMainListOrderType(mainListOrderType: MainListOrderType) {
+        _pingleFilter.update { pingleFilter ->
+            pingleFilter.copy(mainListOrderType = mainListOrderType)
+        }
     }
 
     fun setLastSearchWord(searchWord: String?) {
@@ -182,10 +187,6 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    fun setMainListOrderType(mainListOrderType: MainListOrderType) {
-        _mainListOrderType.value = mainListOrderType
-    }
-
     fun getGroupName(): String = localStorage.groupName
 
     fun deletePingleCancel(meetingId: Long) {
@@ -227,16 +228,17 @@ class HomeViewModel @Inject constructor(
     }
 
     fun getMainListPingleList() {
+        _pingleFilter.value.searchWord
         viewModelScope.launch {
             _mainListPingleListState.emit(UiState.Loading)
-            if (_searchWord.value?.isBlank() == true) {
+            if (_pingleFilter.value.searchWord?.isBlank() == true) {
                 _mainListPingleListState.emit(UiState.Success(emptyList()))
             } else {
                 getMainListPingleListUseCase(
-                    searchWord = _searchWord.value,
-                    category = _category.value?.name,
+                    searchWord = _pingleFilter.value.searchWord,
+                    category = _pingleFilter.value.category?.name,
                     teamId = localStorage.groupId.toLong(),
-                    order = _mainListOrderType.value.name
+                    order = _pingleFilter.value.mainListOrderType.name
                 ).onSuccess { mainListPingleList ->
                     _mainListPingleListState.emit(UiState.Success(mainListPingleList.map { pingleEntity -> pingleEntity.toMainListPingleModel() }))
                 }.onFailure { throwable ->
@@ -253,7 +255,7 @@ class HomeViewModel @Inject constructor(
                 getMapPingleListUseCase(
                     teamId = localStorage.groupId.toLong(),
                     pinId = pinId,
-                    category = _category.value?.name
+                    category = _pingleFilter.value.category?.name
                 ).collect() { mapPingleList ->
                     _mapPingleListState.emit(UiState.Success(Pair(pinId, mapPingleList)))
                 }
@@ -266,14 +268,14 @@ class HomeViewModel @Inject constructor(
     fun getPinListWithoutFilter(isSearching: Boolean = false) {
         viewModelScope.launch {
             _pinEntityListState.value = UiState.Loading
-            if (_searchWord.value?.isBlank() == true) {
+            if (_pingleFilter.value.searchWord?.isBlank() == true) {
                 _pinEntityListState.emit(UiState.Success(Pair(isSearching, emptyList())))
             } else {
                 runCatching {
                     getPinListWithoutFilteringUseCase(
                         teamId = localStorage.groupId.toLong(),
-                        category = _category.value?.name,
-                        searchWord = _searchWord.value
+                        category = _pingleFilter.value.category?.name,
+                        searchWord = _pingleFilter.value.searchWord
                     ).collect() { pinList ->
                         _pinEntityListState.value = UiState.Success(Pair(isSearching, pinList))
                     }

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/mainlist/MainListFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/mainlist/MainListFragment.kt
@@ -137,13 +137,13 @@ class MainListFragment : BindingFragment<FragmentMainListBinding>(R.layout.fragm
                         }
 
                         binding.tvMainListOrderType.text =
-                            stringOf(homeViewModel.mainListOrderType.value.mainListOrderStringRes)
+                            stringOf(homeViewModel.pingleFilter.value.mainListOrderType.mainListOrderStringRes)
 
-                        (!homeViewModel.searchWord.value.isNullOrEmpty()).let { isSearching ->
+                        (!homeViewModel.pingleFilter.value.searchWord.isNullOrEmpty()).let { isSearching ->
                             AmplitudeUtils.trackEventWithProperty(
                                 eventName = COMPLETE_SEARCH_LIST,
                                 propertyName = KEYWORD,
-                                propertyValue = homeViewModel.searchWord.value
+                                propertyValue = homeViewModel.pingleFilter.value.searchWord
                             )
                             with(binding.tvMainListSearchCount) {
                                 visibility = if (isSearching) View.VISIBLE else View.INVISIBLE

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/map/MapFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/map/MapFragment.kt
@@ -209,20 +209,25 @@ class MapFragment : BindingFragment<FragmentMapBinding>(R.layout.fragment_map), 
                 when (uiState) {
                     is UiState.Success -> {
                         if (::naverMap.isInitialized) {
-                            makeMarkers(uiState.data)
+                            makeMarkers(uiState.data.second)
                             mapCardAdapter.clearData()
                             homeViewModel.clearSelectedMarkerPosition()
                         }
 
-                        homeViewModel.searchWord.value?.let { searchWord ->
-                            AmplitudeUtils.trackEventWithProperty(
-                                eventName = COMPLETE_SEARCH_MAP,
-                                propertyName = KEYWORD,
-                                propertyValue = searchWord
-                            )
-                            when {
-                                uiState.data.isEmpty() -> homeViewModel.setHomeViewType(HomeViewType.MAIN_LIST)
-                                else -> moveMapCamera(homeViewModel.markerModelData.value.second[FIRST_INDEX].marker.position)
+                        if (uiState.data.first) {
+                            homeViewModel.searchWord.value?.let { searchWord ->
+                                AmplitudeUtils.trackEventWithProperty(
+                                    eventName = COMPLETE_SEARCH_MAP,
+                                    propertyName = KEYWORD,
+                                    propertyValue = searchWord
+                                )
+                                when {
+                                    uiState.data.second.isEmpty() -> homeViewModel.setHomeViewType(
+                                        HomeViewType.MAIN_LIST
+                                    )
+
+                                    else -> moveMapCamera(homeViewModel.markerModelData.value.second[FIRST_INDEX].marker.position)
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/map/MapFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/home/map/MapFragment.kt
@@ -215,7 +215,7 @@ class MapFragment : BindingFragment<FragmentMapBinding>(R.layout.fragment_map), 
                         }
 
                         if (uiState.data.first) {
-                            homeViewModel.searchWord.value?.let { searchWord ->
+                            homeViewModel.pingleFilter.value.searchWord?.let { searchWord ->
                                 AmplitudeUtils.trackEventWithProperty(
                                     eventName = COMPLETE_SEARCH_MAP,
                                     propertyName = KEYWORD,

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/more/MoreFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/more/MoreFragment.kt
@@ -7,6 +7,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.sopt.pingle.BuildConfig
@@ -24,7 +25,6 @@ import org.sopt.pingle.util.fragment.navigateToWebView
 import org.sopt.pingle.util.fragment.stringOf
 import org.sopt.pingle.util.view.UiState
 import timber.log.Timber
-import javax.inject.Inject
 
 @AndroidEntryPoint
 class MoreFragment : BindingFragment<FragmentMoreBinding>(R.layout.fragment_more) {

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/more/MoreFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/more/MoreFragment.kt
@@ -7,7 +7,6 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.sopt.pingle.BuildConfig
@@ -16,7 +15,7 @@ import org.sopt.pingle.data.service.KakaoAuthService
 import org.sopt.pingle.databinding.FragmentMoreBinding
 import org.sopt.pingle.presentation.type.SnackbarType
 import org.sopt.pingle.presentation.ui.mygroup.MyGroupActivity
-import org.sopt.pingle.presentation.ui.onboarding.onboardingexplanation.OnboardingExplanationActivity
+import org.sopt.pingle.presentation.ui.onboarding.onboarding.OnboardingActivity
 import org.sopt.pingle.util.AmplitudeUtils
 import org.sopt.pingle.util.base.BindingFragment
 import org.sopt.pingle.util.component.AllModalDialogFragment
@@ -25,6 +24,7 @@ import org.sopt.pingle.util.fragment.navigateToWebView
 import org.sopt.pingle.util.fragment.stringOf
 import org.sopt.pingle.util.view.UiState
 import timber.log.Timber
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MoreFragment : BindingFragment<FragmentMoreBinding>(R.layout.fragment_more) {
@@ -76,47 +76,49 @@ class MoreFragment : BindingFragment<FragmentMoreBinding>(R.layout.fragment_more
     }
 
     private fun collectData() {
-        moreViewModel.logoutState.flowWithLifecycle(viewLifecycleOwner.lifecycle).onEach { logoutState ->
-            when (logoutState) {
-                is UiState.Success -> {
-                    AmplitudeUtils.trackEvent(LOGOUT_APP)
-                    navigateToOnboardingExplanation()
-                }
-
-                is UiState.Error -> {
-                    Timber.d(FAILURE_LOGOUT)
-                }
-
-                else -> {}
-            }
-        }.launchIn(viewLifecycleOwner.lifecycleScope)
-
-        moreViewModel.withDrawState.flowWithLifecycle(viewLifecycleOwner.lifecycle).onEach { withDrawState ->
-            when (withDrawState) {
-                is UiState.Success -> {
-                    AmplitudeUtils.trackEvent(WITHDRAW_APP)
-                    kakaoAuthService.withdrawKakao()
-                    navigateToOnboardingExplanation()
-                }
-
-                is UiState.Error -> {
-                    when (withDrawState.code) {
-                        FAILURE_OWNER -> {
-                            PingleSnackbar.makeSnackbar(
-                                requireView(),
-                                stringOf(R.string.more_snackbar_failure),
-                                SNACKBAR_BOTTOM_MARGIN,
-                                SnackbarType.WARNING
-                            )
-                        }
-
-                        else -> Timber.d("$FAILURE_LOGOUT : ${withDrawState.message}")
+        moreViewModel.logoutState.flowWithLifecycle(viewLifecycleOwner.lifecycle)
+            .onEach { logoutState ->
+                when (logoutState) {
+                    is UiState.Success -> {
+                        AmplitudeUtils.trackEvent(LOGOUT_APP)
+                        navigateToOnboarding()
                     }
-                }
 
-                else -> {}
-            }
-        }.launchIn(viewLifecycleOwner.lifecycleScope)
+                    is UiState.Error -> {
+                        Timber.d(FAILURE_LOGOUT)
+                    }
+
+                    else -> {}
+                }
+            }.launchIn(viewLifecycleOwner.lifecycleScope)
+
+        moreViewModel.withDrawState.flowWithLifecycle(viewLifecycleOwner.lifecycle)
+            .onEach { withDrawState ->
+                when (withDrawState) {
+                    is UiState.Success -> {
+                        AmplitudeUtils.trackEvent(WITHDRAW_APP)
+                        kakaoAuthService.withdrawKakao()
+                        navigateToOnboarding()
+                    }
+
+                    is UiState.Error -> {
+                        when (withDrawState.code) {
+                            FAILURE_OWNER -> {
+                                PingleSnackbar.makeSnackbar(
+                                    requireView(),
+                                    stringOf(R.string.more_snackbar_failure),
+                                    SNACKBAR_BOTTOM_MARGIN,
+                                    SnackbarType.WARNING
+                                )
+                            }
+
+                            else -> Timber.d("$FAILURE_LOGOUT : ${withDrawState.message}")
+                        }
+                    }
+
+                    else -> {}
+                }
+            }.launchIn(viewLifecycleOwner.lifecycleScope)
 
         moreViewModel.userInfoState.flowWithLifecycle(viewLifecycleOwner.lifecycle)
             .onEach { userInfoState ->
@@ -130,8 +132,8 @@ class MoreFragment : BindingFragment<FragmentMoreBinding>(R.layout.fragment_more
             }.launchIn(viewLifecycleOwner.lifecycleScope)
     }
 
-    private fun navigateToOnboardingExplanation() {
-        Intent(requireContext(), OnboardingExplanationActivity::class.java).apply {
+    private fun navigateToOnboarding() {
+        Intent(requireContext(), OnboardingActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK
             startActivity(this)
         }

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/more/MoreFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/more/MoreFragment.kt
@@ -14,8 +14,8 @@ import org.sopt.pingle.R
 import org.sopt.pingle.data.service.KakaoAuthService
 import org.sopt.pingle.databinding.FragmentMoreBinding
 import org.sopt.pingle.presentation.type.SnackbarType
+import org.sopt.pingle.presentation.ui.auth.AuthActivity
 import org.sopt.pingle.presentation.ui.mygroup.MyGroupActivity
-import org.sopt.pingle.presentation.ui.onboarding.onboarding.OnboardingActivity
 import org.sopt.pingle.util.AmplitudeUtils
 import org.sopt.pingle.util.base.BindingFragment
 import org.sopt.pingle.util.component.AllModalDialogFragment
@@ -81,7 +81,7 @@ class MoreFragment : BindingFragment<FragmentMoreBinding>(R.layout.fragment_more
                 when (logoutState) {
                     is UiState.Success -> {
                         AmplitudeUtils.trackEvent(LOGOUT_APP)
-                        navigateToOnboarding()
+                        navigateToAuth()
                     }
 
                     is UiState.Error -> {
@@ -98,7 +98,7 @@ class MoreFragment : BindingFragment<FragmentMoreBinding>(R.layout.fragment_more
                     is UiState.Success -> {
                         AmplitudeUtils.trackEvent(WITHDRAW_APP)
                         kakaoAuthService.withdrawKakao()
-                        navigateToOnboarding()
+                        navigateToAuth()
                     }
 
                     is UiState.Error -> {
@@ -132,8 +132,8 @@ class MoreFragment : BindingFragment<FragmentMoreBinding>(R.layout.fragment_more
             }.launchIn(viewLifecycleOwner.lifecycleScope)
     }
 
-    private fun navigateToOnboarding() {
-        Intent(requireContext(), OnboardingActivity::class.java).apply {
+    private fun navigateToAuth() {
+        Intent(requireContext(), AuthActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK
             startActivity(this)
         }

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/more/MoreFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/more/MoreFragment.kt
@@ -17,6 +17,7 @@ import org.sopt.pingle.databinding.FragmentMoreBinding
 import org.sopt.pingle.presentation.type.SnackbarType
 import org.sopt.pingle.presentation.ui.auth.AuthActivity
 import org.sopt.pingle.presentation.ui.mygroup.MyGroupActivity
+import org.sopt.pingle.presentation.ui.onboarding.onboarding.OnboardingActivity.Companion.FROM_ACTIVITY
 import org.sopt.pingle.util.AmplitudeUtils
 import org.sopt.pingle.util.base.BindingFragment
 import org.sopt.pingle.util.component.AllModalDialogFragment
@@ -135,6 +136,7 @@ class MoreFragment : BindingFragment<FragmentMoreBinding>(R.layout.fragment_more
     private fun navigateToAuth() {
         Intent(requireContext(), AuthActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK
+            putExtra(FROM_ACTIVITY, MORE_FRAGMENT)
             startActivity(this)
         }
     }
@@ -186,5 +188,7 @@ class MoreFragment : BindingFragment<FragmentMoreBinding>(R.layout.fragment_more
         private const val WITHDRAW_APP = "withdraw_app"
 
         private const val START_MYGROUP = "start_mygroup"
+
+        const val MORE_FRAGMENT = "MoreFragment"
     }
 }

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/ranking/RankingFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/ranking/RankingFragment.kt
@@ -42,7 +42,7 @@ class RankingFragment : BindingFragment<FragmentRankingBinding>(R.layout.fragmen
             addOnScrollListener(object : RecyclerView.OnScrollListener() {
                 override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
                     super.onScrollStateChanged(recyclerView, newState)
-                    if (newState == RecyclerView.SCROLL_STATE_IDLE) {
+                    if (newState == RecyclerView.SCROLL_STATE_DRAGGING) {
                         AmplitudeUtils.trackEvent(SCROLL_RANKING)
                     }
                 }

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/mygroup/MyGroupActivity.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/mygroup/MyGroupActivity.kt
@@ -142,7 +142,7 @@ class MyGroupActivity : BindingActivity<ActivityMyGroupBinding>(R.layout.activit
             startActivity(this)
         }
     }
-    
+
     private fun makeEllipsisGroupName(groupName: String): String {
         return if (groupName.length > GROUP_NAME_MAX_LENGTH) {
             "${groupName.substring(SUBSTRING_START_INDEX, SUBSTRING_END_INDEX) + ELLIPSIS}"

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/mygroup/MyGroupActivity.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/mygroup/MyGroupActivity.kt
@@ -98,10 +98,11 @@ class MyGroupActivity : BindingActivity<ActivityMyGroupBinding>(R.layout.activit
     private fun showChangeGroupModal(clickedEntity: MyGroupEntity) {
         AmplitudeUtils.trackEvent(CLICK_OTHERGROUP)
         binding.layoutMyGroupSelectedMenu.visibility = View.INVISIBLE
+
         MyGroupModalDialogFragment(
             title = getString(
                 R.string.my_group_modal_move_question,
-                clickedEntity.name
+                makeEllipsisGroupName(clickedEntity.name)
             ),
             buttonText = stringOf(R.string.my_group_modal_change),
             textButtonText = stringOf(R.string.my_group_modal_back),
@@ -141,10 +142,22 @@ class MyGroupActivity : BindingActivity<ActivityMyGroupBinding>(R.layout.activit
             startActivity(this)
         }
     }
+    
+    private fun makeEllipsisGroupName(groupName: String): String {
+        return if (groupName.length > GROUP_NAME_MAX_LENGTH) {
+            "${groupName.substring(SUBSTRING_START_INDEX, SUBSTRING_END_INDEX) + ELLIPSIS}"
+        } else {
+            groupName
+        }
+    }
 
     companion object {
         private const val CHANGE_MODAL = "ChangeGroupModal"
         private const val SNACKBAR_BOTTOM_MARGIN = 57
+        private const val SUBSTRING_START_INDEX = 0
+        private const val SUBSTRING_END_INDEX = 12
+        private const val GROUP_NAME_MAX_LENGTH = 13
+        private const val ELLIPSIS = "..."
 
         const val CLICK_INVITECODE = "click_invitecode"
         const val CLICK_INVITECODE_COPY = "click_invitecode_copy"

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/mygroup/MyGroupActivity.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/mygroup/MyGroupActivity.kt
@@ -159,11 +159,11 @@ class MyGroupActivity : BindingActivity<ActivityMyGroupBinding>(R.layout.activit
         private const val GROUP_NAME_MAX_LENGTH = 13
         private const val ELLIPSIS = "..."
 
-        const val CLICK_INVITECODE = "click_invitecode"
-        const val CLICK_INVITECODE_COPY = "click_invitecode_copy"
-        const val CLICK_INVITECODE_SHARE = "click_invitecode_share"
-        const val CLICK_OTHERGROUP = "click_othergroup"
-        const val CLICK_OTHERGROUP_CHANGE = "click_othergroup_change"
-        const val CLICK_NEWGROUP = "click_newgroup"
+        private const val CLICK_INVITECODE = "click_invitecode"
+        private const val CLICK_INVITECODE_COPY = "click_invitecode_copy"
+        private const val CLICK_INVITECODE_SHARE = "click_invitecode_share"
+        private const val CLICK_OTHERGROUP = "click_othergroup"
+        private const val CLICK_OTHERGROUP_CHANGE = "click_othergroup_change"
+        private const val CLICK_NEWGROUP = "click_newgroup"
     }
 }

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/mygroup/MyGroupActivity.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/mygroup/MyGroupActivity.kt
@@ -143,12 +143,9 @@ class MyGroupActivity : BindingActivity<ActivityMyGroupBinding>(R.layout.activit
         }
     }
 
-    private fun makeEllipsisGroupName(groupName: String): String {
-        return if (groupName.length > GROUP_NAME_MAX_LENGTH) {
-            "${groupName.substring(SUBSTRING_START_INDEX, SUBSTRING_END_INDEX) + ELLIPSIS}"
-        } else {
-            groupName
-        }
+    private fun makeEllipsisGroupName(groupName: String): String = when {
+        groupName.length > GROUP_NAME_MAX_LENGTH -> groupName.substring(SUBSTRING_START_INDEX, SUBSTRING_END_INDEX) + ELLIPSIS
+        else -> groupName
     }
 
     companion object {

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/onboarding/onboardingexplanation/OnboardingExplanationActivity.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/onboarding/onboardingexplanation/OnboardingExplanationActivity.kt
@@ -18,6 +18,7 @@ import org.sopt.pingle.presentation.type.SnackbarType
 import org.sopt.pingle.presentation.ui.auth.AuthActivity
 import org.sopt.pingle.presentation.ui.auth.AuthViewModel
 import org.sopt.pingle.presentation.ui.main.MainActivity
+import org.sopt.pingle.presentation.ui.onboarding.onboarding.OnboardingActivity
 import org.sopt.pingle.presentation.ui.onboarding.onboardingexplanation.OnboardingExplanationAdapter.Companion.ONBOARDING_SIZE
 import org.sopt.pingle.presentation.ui.onboarding.onboardingexplanation.OnboardingExplanationAdapter.Companion.POSITION_MINUS
 import org.sopt.pingle.util.activity.FINISH_INTERVAL_TIME
@@ -54,7 +55,13 @@ class OnboardingExplanationActivity :
 
     private fun initLayout() {
         if (authViewModel.isLocalToken()) {
-            if (authViewModel.isLocalGroupId()) navigateToMain() else authViewModel.getUserInfo()
+            if (authViewModel.isLocalGroupId()) {
+                navigateToMain()
+            }
+            else {
+                authViewModel.getUserInfo()
+                navigateToOnboarding()
+            }
         }
 
         initAdapter()
@@ -144,6 +151,13 @@ class OnboardingExplanationActivity :
 
     private fun navigateToMain() {
         Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK
+            startActivity(this)
+        }
+    }
+
+    private fun navigateToOnboarding() {
+        Intent(this, OnboardingActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK
             startActivity(this)
         }

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/onboarding/onboardingexplanation/OnboardingExplanationActivity.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/onboarding/onboardingexplanation/OnboardingExplanationActivity.kt
@@ -57,8 +57,7 @@ class OnboardingExplanationActivity :
         if (authViewModel.isLocalToken()) {
             if (authViewModel.isLocalGroupId()) {
                 navigateToMain()
-            }
-            else {
+            } else {
                 authViewModel.getUserInfo()
                 navigateToOnboarding()
             }

--- a/app/src/main/java/org/sopt/pingle/util/component/PingleSearch.kt
+++ b/app/src/main/java/org/sopt/pingle/util/component/PingleSearch.kt
@@ -44,6 +44,10 @@ class PingleSearch @JvmOverloads constructor(
                     if (text.isNullOrEmpty()) View.GONE else View.VISIBLE
             }
 
+            etSearchPingleEditText.setOnEditorActionListener { textView, _, _ ->
+                textView.text.isEmpty()
+            }
+
             ivSearchPingleClear.setOnClickListener {
                 _binding.etSearchPingleEditText.text.clear()
             }

--- a/app/src/main/res/layout/dialog_my_group_modal.xml
+++ b/app/src/main/res/layout/dialog_my_group_modal.xml
@@ -37,7 +37,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
-                app:layout_constraintGuide_end="@dimen/dialog_all_modal_horizontal_margin" />
+                app:layout_constraintGuide_end="@dimen/dialog_my_group_modal_horizontal_margin" />
 
             <TextView
                 android:id="@+id/tv_my_group_modal_title"

--- a/app/src/main/res/layout/item_ranking.xml
+++ b/app/src/main/res/layout/item_ranking.xml
@@ -19,7 +19,7 @@
             android:layout_marginTop="16dp"
             android:gravity="center"
             android:minWidth="22dp"
-            android:textAppearance="@style/TextAppearance.Pingle.Cap.Bold.12"
+            android:textAppearance="@style/TextAppearance.Pingle.Sub.Bold.16"
             android:textColor="@color/white"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -51,7 +51,7 @@
     <dimen name="dialog_horizontal_margin">24dp</dimen>
     <dimen name="dialog_all_modal_horizontal_margin">34dp</dimen>
     <dimen name="dialog_map_modal_horizontal_margin">24dp</dimen>
-    <dimen name="dialog_my_group_modal_horizontal_margin">34dp</dimen>
+    <dimen name="dialog_my_group_modal_horizontal_margin">26dp</dimen>
 
     <!-- card -->
     <dimen name="card_horizontal_margin">24dp</dimen>


### PR DESCRIPTION
## Related issue 🛠
- closed #243 

## Work Description ✏️
- 3차 스프린트 QA 수정사항을 반영하였습니다.
    - 서치바 -> 입력 전 검색 버튼 비활성화
    - 지도/리스트뷰 -> 검색창에서 뒤로가기 클릭 시 검색 취소 + 검색 페이지 이동
    - 랭킹 -> 숫자 크기 12Bold -> 16Bold
    - 랭킹 -> 데이터 텍소노미 스크롤 시작 시점으로 변경
    - 단체 변경 후 홈 화면 진입 시 검색결과 유지되어 있는 문제 해결
    -  검색 + 지도 뷰에서 칩 필터링을 진행하는 경우 검색 결과가 없어도 지도뷰 유지
    - 리이슈 문제 완전 해결 ㅋ

## Screenshot 📸
**서치바 -> 입력 전 검색 버튼 비활성화**

https://github.com/TeamPINGLE/PINGLE-ANDROID/assets/103172971/c803c986-9e98-4ee0-bb40-f7167e475dc4

**지도/리스트뷰 -> 검색창에서 뒤로가기 클릭 시 검색 취소 + 검색 페이지 이동**

https://github.com/TeamPINGLE/PINGLE-ANDROID/assets/103172971/b6b800d4-7910-4f8c-9185-fcdf580493bd

**단체 변경 후 홈 화면 진입 시 검색결과 유지되어 있는 문제 해결**

https://github.com/TeamPINGLE/PINGLE-ANDROID/assets/103172971/671c0e8d-3fc8-45e0-8473-ee936c9744f5

**검색 + 지도 뷰에서 칩 필터링을 진행하는 경우 검색 결과가 없어도 지도뷰 유지**

https://github.com/TeamPINGLE/PINGLE-ANDROID/assets/103172971/d4f2b1be-6867-4aee-bcd0-ebc3b4b68da8

## Uncompleted Tasks 😅
- [x] 단체 변경 후 홈 화면 진입 시 검색결과 유지되어 있는 문제 해결
- [x]  검색 + 지도 뷰에서 칩 필터링을 진행하는 경우 검색 결과가 없어도 지도뷰 유지

## To Reviewers 📢
- 토큰 재발급.. 따로 이슈 파서 진행하겠습니다 ㅋㅋ 하암,,,
- 서치바 입력 전 검색 버튼 비활성화 -> 서치바가 있는 모든 뷰에 적용해달라고 하셔서 커스텀 뷰 만든 부분을 수정하였습니다. 요거 있는 뷰 담당한 분은 제외하고 해주시면 될 것 같아요 ~
- 검색 뷰 키보드 관련 디자인 측과 얘기해서 제외하기로 결정했습니다.
- 지도/리스트뷰 뒤로가기 관련 제 실기기에서 잘 되는 거 확인했는데,, 다른 분들도 한 번 확인해주시면 좋을 것 같습니다!
- 단체 변경 후 홈 화면 진입 시 검색결과 유지되어 있는 문제 해결 -> 이거 해결은 했는데,, 로직이 맘에 안 들어요,, 근데 SharedPreference를 사용하고 있는 한, 이 방법이 최선일 것 같기도 합니다,, (OnSharedPreferenceChangeListener를 사용해서 해결했어요)
-  검색 + 지도 뷰에서 칩 필터링을 진행하는 경우 검색 결과가 없어도 지도뷰 유지 -> ㅋㅋ 이전 검색 값을 저장하는 방식으로 구현하였는데,,, 로직이 맘에 안 들어요,, 좋은 방법 있다면 의견 플리즈
- 리이슈 문제 완전 해결 (인 듯함 ㅋㅋ)