### PR TITLE
[fix] 3차 스프린트 QA 수정사항 반영

### DIFF
--- a/app/src/main/java/org/sopt/pingle/presentation/ui/joingroup/JoinGroupCodeActivity.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/joingroup/JoinGroupCodeActivity.kt
@@ -61,9 +61,9 @@ class JoinGroupCodeActivity :
     }
 
     private fun addObservers() {
-        viewModel.joinGroupCodeEditText.observe(this) { editText ->
+        viewModel.joinGroupCodeEditText.flowWithLifecycle(lifecycle).onEach { editText ->
             binding.btnJoinGroupCodeNext.isEnabled = editText.isNotEmpty()
-        }
+        }.launchIn(lifecycleScope)
     }
 
     private fun collectData() {

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/joingroup/JoinGroupCodeActivity.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/joingroup/JoinGroupCodeActivity.kt
@@ -32,7 +32,6 @@ class JoinGroupCodeActivity :
 
         initLayout()
         addListeners()
-        addObservers()
         collectData()
     }
 
@@ -58,12 +57,6 @@ class JoinGroupCodeActivity :
         binding.includeJoinGroupCodeTopbar.ivAllTopbarArrowWithTitleArrowLeft.setOnClickListener {
             finish()
         }
-    }
-
-    private fun addObservers() {
-        viewModel.joinGroupCodeEditText.flowWithLifecycle(lifecycle).onEach { editText ->
-            binding.btnJoinGroupCodeNext.isEnabled = editText.isNotEmpty()
-        }.launchIn(lifecycleScope)
     }
 
     private fun collectData() {
@@ -130,6 +123,10 @@ class JoinGroupCodeActivity :
 
                 is UiState.Empty -> Timber.tag(JOIN_GROUP_CODE_ACTIVITY).d(EMPTY)
             }
+        }.launchIn(lifecycleScope)
+
+        viewModel.joinGroupCodeEditText.flowWithLifecycle(lifecycle).onEach { editText ->
+            binding.btnJoinGroupCodeNext.isEnabled = editText.isNotEmpty()
         }.launchIn(lifecycleScope)
     }
 

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/joingroup/JoinViewModel.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/joingroup/JoinViewModel.kt
@@ -45,7 +45,7 @@ class JoinViewModel @Inject constructor(
         MutableStateFlow<UiState<GroupEntity>>(UiState.Empty)
 
     val joinGroupCodeState get() = _joinGroupCodeState
-    val joinGroupCodeEditText = MutableLiveData<String>()
+    val joinGroupCodeEditText = MutableStateFlow<String>("")
 
     private var oldPosition = DEFAULT_OLD_POSITION
 

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/joingroup/JoinViewModel.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/joingroup/JoinViewModel.kt
@@ -1,6 +1,5 @@
 package org.sopt.pingle.presentation.ui.joingroup
 
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/main/mypingle/MyPingleFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/main/mypingle/MyPingleFragment.kt
@@ -58,7 +58,7 @@ class MyPingleFragment : BindingFragment<FragmentMyPingleBinding>(R.layout.fragm
         binding.rvMyPingle.addOnScrollListener(object : RecyclerView.OnScrollListener() {
             override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
                 super.onScrollStateChanged(recyclerView, newState)
-                if (newState == RecyclerView.SCROLL_STATE_IDLE) {
+                if (newState == RecyclerView.SCROLL_STATE_DRAGGING) {
                     when (viewModel.myPingleType.value) {
                         MyPingleType.SOON -> AmplitudeUtils.trackEvent(SCROLL_SOONPINGLE)
                         MyPingleType.DONE -> AmplitudeUtils.trackEvent(SCROLL_DONEPINGLE)

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/newgroup/newgroupinput/NewGroupInputFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/newgroup/newgroupinput/NewGroupInputFragment.kt
@@ -6,6 +6,7 @@ import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.sopt.pingle.R
@@ -48,7 +49,9 @@ class NewGroupInputFragment :
     }
 
     private fun collectNewGroupCheckNameState() {
-        newGroupViewModel.newGroupCheckNameState.flowWithLifecycle(lifecycle).onEach { uiState ->
+        newGroupViewModel.newGroupCheckNameState.flowWithLifecycle(lifecycle)
+            .distinctUntilChanged()
+            .onEach { uiState ->
             when (uiState) {
                 is UiState.Success -> {
                     if (uiState.data.result) {

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/newgroup/newgroupinput/NewGroupInputFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/newgroup/newgroupinput/NewGroupInputFragment.kt
@@ -32,6 +32,13 @@ class NewGroupInputFragment :
         collectData()
     }
 
+    override fun onResume() {
+        super.onResume()
+
+        binding.etNewGroupInputGroupName.btnEditTextCheck.isEnabled =
+            newGroupViewModel.isNewGroupBtnCheckName.value
+    }
+
     private fun addListeners() {
         binding.etNewGroupInputGroupName.btnEditTextCheck.setOnClickListener { newGroupViewModel.getNewGroupCheckName() }
     }

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/newgroup/newgroupinput/NewGroupInputFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/newgroup/newgroupinput/NewGroupInputFragment.kt
@@ -52,31 +52,35 @@ class NewGroupInputFragment :
         newGroupViewModel.newGroupCheckNameState.flowWithLifecycle(lifecycle)
             .distinctUntilChanged()
             .onEach { uiState ->
-            when (uiState) {
-                is UiState.Success -> {
-                    if (uiState.data.result) {
-                        PingleSnackbar.makeSnackbar(
-                            binding.root,
-                            stringOf(R.string.new_group_input_snackbar_guide),
-                            SNACKBAR_BOTTOM_MARGIN,
-                            SnackbarType.GUIDE
-                        )
-                        binding.etNewGroupInputGroupName.btnEditTextCheck.isEnabled = false
-                        newGroupViewModel.setIsNewGroupBtnCheckName(true)
-                    } else {
-                        PingleSnackbar.makeSnackbar(
-                            binding.root,
-                            stringOf(R.string.new_group_input_snackbar_warning),
-                            SNACKBAR_BOTTOM_MARGIN,
-                            SnackbarType.WARNING
+                when (uiState) {
+                    is UiState.Success -> {
+                        if (uiState.data.result) {
+                            PingleSnackbar.makeSnackbar(
+                                binding.root,
+                                stringOf(R.string.new_group_input_snackbar_guide),
+                                SNACKBAR_BOTTOM_MARGIN,
+                                SnackbarType.GUIDE
+                            )
+                            binding.etNewGroupInputGroupName.btnEditTextCheck.isEnabled = false
+                            newGroupViewModel.setIsNewGroupBtnCheckName(true)
+                        } else {
+                            PingleSnackbar.makeSnackbar(
+                                binding.root,
+                                stringOf(R.string.new_group_input_snackbar_warning),
+                                SNACKBAR_BOTTOM_MARGIN,
+                                SnackbarType.WARNING
+                            )
+                        }
+                        AmplitudeUtils.trackEventWithProperty(
+                            COMPLETE_DOUBLECHECK,
+                            GROUP_NAME,
+                            binding.etNewGroupInputGroupName.editText.text
                         )
                     }
-                    AmplitudeUtils.trackEventWithProperty(COMPLETE_DOUBLECHECK, GROUP_NAME, binding.etNewGroupInputGroupName.editText.text)
-                }
 
-                else -> {}
-            }
-        }.launchIn(lifecycleScope)
+                    else -> {}
+                }
+            }.launchIn(lifecycleScope)
     }
 
     companion object {

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/newgroup/newgroupkeyword/NewGroupKeywordFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/newgroup/newgroupkeyword/NewGroupKeywordFragment.kt
@@ -2,6 +2,7 @@ package org.sopt.pingle.presentation.ui.newgroup.newgroupkeyword
 
 import android.os.Bundle
 import android.view.View
+import androidx.core.view.forEach
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
@@ -30,11 +31,13 @@ class NewGroupKeywordFragment :
 
     override fun onResume() {
         super.onResume()
-        if (newGroupViewModel.newGroupKeywordValue.value.isNotEmpty()) {
-            for (i in 0 until binding.cgNewGroupKeyword.childCount) {
-                val childChip = binding.cgNewGroupKeyword.getChildAt(i) as Chip
-                if (childChip.text == newGroupViewModel.newGroupKeywordValue.value) {
-                    childChip.isChecked = true
+
+        with(newGroupViewModel.newGroupKeywordValue.value) {
+            if(isNotEmpty()) {
+                binding.cgNewGroupKeyword.forEach { childChip ->
+                    (childChip as Chip).let {  chip ->
+                        if (chip.text == this) chip.isChecked = true
+                    }
                 }
             }
         }

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/newgroup/newgroupkeyword/NewGroupKeywordFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/newgroup/newgroupkeyword/NewGroupKeywordFragment.kt
@@ -33,9 +33,9 @@ class NewGroupKeywordFragment :
         super.onResume()
 
         with(newGroupViewModel.newGroupKeywordValue.value) {
-            if(isNotEmpty()) {
+            if (isNotEmpty()) {
                 binding.cgNewGroupKeyword.forEach { childChip ->
-                    (childChip as Chip).let {  chip ->
+                    (childChip as Chip).let { chip ->
                         if (chip.text == this) chip.isChecked = true
                     }
                 }

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/newgroup/newgroupkeyword/NewGroupKeywordFragment.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/newgroup/newgroupkeyword/NewGroupKeywordFragment.kt
@@ -28,6 +28,18 @@ class NewGroupKeywordFragment :
         collectData()
     }
 
+    override fun onResume() {
+        super.onResume()
+        if (newGroupViewModel.newGroupKeywordValue.value.isNotEmpty()) {
+            for (i in 0 until binding.cgNewGroupKeyword.childCount) {
+                val childChip = binding.cgNewGroupKeyword.getChildAt(i) as Chip
+                if (childChip.text == newGroupViewModel.newGroupKeywordValue.value) {
+                    childChip.isChecked = true
+                }
+            }
+        }
+    }
+
     private fun initLayout() {
         newGroupViewModel.getNewGroupKeywords()
     }

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/splash/SplashActivity.kt
@@ -2,17 +2,19 @@ package org.sopt.pingle.presentation.ui.splash
 
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.sopt.pingle.R
 import org.sopt.pingle.data.datasource.local.PingleLocalDataSource
 import org.sopt.pingle.databinding.ActivitySplashBinding
+import org.sopt.pingle.presentation.ui.onboarding.onboarding.OnboardingActivity
 import org.sopt.pingle.presentation.ui.onboarding.onboardingexplanation.OnboardingExplanationActivity
 import org.sopt.pingle.util.base.BindingActivity
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class SplashActivity : BindingActivity<ActivitySplashBinding>(R.layout.activity_splash) {
@@ -27,12 +29,23 @@ class SplashActivity : BindingActivity<ActivitySplashBinding>(R.layout.activity_
     private fun loadSplashScreen() {
         lifecycleScope.launch {
             delay(SPLASH_SCREEN_DELAY_TIME)
-            navigateToAuth()
+            if (localStorage.accessToken != "") {
+                navigateToOnboarding()
+            } else {
+                navigateToOnboardingExplanation()
+            }
         }
     }
 
-    private fun navigateToAuth() {
+    private fun navigateToOnboardingExplanation() {
         Intent(this, OnboardingExplanationActivity::class.java).apply {
+            startActivity(this)
+        }
+        finish()
+    }
+
+    private fun navigateToOnboarding() {
+        Intent(this, OnboardingActivity::class.java).apply {
             startActivity(this)
         }
         finish()

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/splash/SplashActivity.kt
@@ -2,43 +2,55 @@ package org.sopt.pingle.presentation.ui.splash
 
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
+import androidx.activity.viewModels
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import org.sopt.pingle.R
-import org.sopt.pingle.data.datasource.local.PingleLocalDataSource
 import org.sopt.pingle.databinding.ActivitySplashBinding
+import org.sopt.pingle.presentation.ui.auth.AuthViewModel
+import org.sopt.pingle.presentation.ui.main.MainActivity
 import org.sopt.pingle.presentation.ui.onboarding.onboarding.OnboardingActivity
 import org.sopt.pingle.presentation.ui.onboarding.onboardingexplanation.OnboardingExplanationActivity
 import org.sopt.pingle.util.base.BindingActivity
-import javax.inject.Inject
+import org.sopt.pingle.util.view.UiState
 
 @AndroidEntryPoint
 class SplashActivity : BindingActivity<ActivitySplashBinding>(R.layout.activity_splash) {
-    @Inject
-    lateinit var localStorage: PingleLocalDataSource
+    private val authViewModel by viewModels<AuthViewModel>()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
         super.onCreate(savedInstanceState)
         loadSplashScreen()
+        collectData()
     }
 
     private fun loadSplashScreen() {
         lifecycleScope.launch {
             delay(SPLASH_SCREEN_DELAY_TIME)
-            if (localStorage.accessToken != "") {
-                navigateToOnboarding()
-            } else {
-                navigateToOnboardingExplanation()
-            }
+            if (authViewModel.isLocalToken()) {
+                if (authViewModel.isLocalGroupId()) navigateToMain() else authViewModel.getUserInfo()
+            } else navigateToOnboardingExplanation()
         }
     }
 
-    private fun navigateToOnboardingExplanation() {
-        Intent(this, OnboardingExplanationActivity::class.java).apply {
+    private fun collectData() {
+        authViewModel.userInfoState.flowWithLifecycle(lifecycle).onEach { uiState ->
+            when (uiState) {
+                is UiState.Success -> if (uiState.data.groups.isEmpty()) navigateToOnboarding() else navigateToMain()
+                else -> Unit
+            }
+        }.launchIn(lifecycleScope)
+    }
+
+    private fun navigateToMain() {
+        Intent(this, MainActivity::class.java).apply {
             startActivity(this)
         }
         finish()
@@ -46,6 +58,13 @@ class SplashActivity : BindingActivity<ActivitySplashBinding>(R.layout.activity_
 
     private fun navigateToOnboarding() {
         Intent(this, OnboardingActivity::class.java).apply {
+            startActivity(this)
+        }
+        finish()
+    }
+
+    private fun navigateToOnboardingExplanation() {
+        Intent(this, OnboardingExplanationActivity::class.java).apply {
             startActivity(this)
         }
         finish()

--- a/app/src/main/java/org/sopt/pingle/presentation/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/org/sopt/pingle/presentation/ui/splash/SplashActivity.kt
@@ -36,7 +36,9 @@ class SplashActivity : BindingActivity<ActivitySplashBinding>(R.layout.activity_
             delay(SPLASH_SCREEN_DELAY_TIME)
             if (authViewModel.isLocalToken()) {
                 if (authViewModel.isLocalGroupId()) navigateToMain() else authViewModel.getUserInfo()
-            } else navigateToOnboardingExplanation()
+            } else {
+                navigateToOnboardingExplanation()
+            }
         }
     }
 

--- a/app/src/main/res/layout/activity_join_group_code.xml
+++ b/app/src/main/res/layout/activity_join_group_code.xml
@@ -108,8 +108,10 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="4dp"
+                android:maxLines="2"
                 android:textAppearance="@style/TextAppearance.Pingle.Title.Semi.24"
                 android:textColor="@color/black"
+                app:layout_constraintEnd_toStartOf="@id/gl_group_info_end"
                 app:layout_constraintStart_toEndOf="@id/gl_group_info_start"
                 app:layout_constraintTop_toBottomOf="@id/tv_join_group_code_tag"
                 tools:text="SOPT" />
@@ -170,8 +172,8 @@
             app:layout_constraintEnd_toStartOf="@id/gl_end"
             app:layout_constraintStart_toEndOf="@id/gl_start"
             app:layout_constraintTop_toBottomOf="@id/layout_join_group_code_group_info"
-            app:pingleEditTextMaxLength="12"
             app:pingleEditTextHint="@string/join_group_code_invitation_hint"
+            app:pingleEditTextMaxLength="12"
             app:pingleEditTextTitle="@string/join_group_code_invitation" />
 
         <TextView

--- a/app/src/main/res/layout/activity_new_group_announcement.xml
+++ b/app/src/main/res/layout/activity_new_group_announcement.xml
@@ -31,12 +31,13 @@
 
         <TextView
             android:id="@+id/tv_new_group_announcement_group_name"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_marginTop="16dp"
             android:textAppearance="@style/TextAppearance.Pingle.Body.Med.16"
             android:textColor="@color/g_03"
             app:layout_constraintStart_toEndOf="@id/gl_start"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_new_group_announcement_title"
             tools:text="@string/new_group_announcement_group_name" />
 

--- a/app/src/main/res/layout/item_join_group_search.xml
+++ b/app/src/main/res/layout/item_join_group_search.xml
@@ -23,38 +23,48 @@
             app:layout_constraintGuide_begin="@dimen/spacing18" />
 
         <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/gl_top"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            app:layout_constraintGuide_begin="@dimen/spacing34" />
+
+        <androidx.constraintlayout.widget.Guideline
             android:id="@+id/gl_end"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="vertical"
-            app:layout_constraintGuide_end="@dimen/spacing18" />
+            app:layout_constraintGuide_end="@dimen/spacing10" />
 
-        <TextView
-            android:id="@+id/tv_join_group_search_tag"
-            android:layout_width="0dp"
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/gl_bottom"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginVertical="35dp"
-            android:background="@drawable/shape_border_radius_50"
-            android:backgroundTint="@color/g_10"
-            android:paddingHorizontal="@dimen/spacing8"
-            android:paddingVertical="@dimen/spacing3"
+            android:orientation="horizontal"
+            app:layout_constraintGuide_end="@dimen/spacing34" />
+
+        <org.sopt.pingle.util.component.PingleChip
+            android:id="@+id/tv_join_group_search_tag"
+            style="@style/Theme.Pingle.Chip.Tag.S"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             android:text="@{joinGroupSearch.keyword}"
-            android:textAppearance="@style/TextAppearance.Pingle.Cap.Semi.10"
-            android:textColor="@color/pingle_green"
-            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/gl_bottom"
             app:layout_constraintStart_toEndOf="@id/gl_start"
-            app:layout_constraintTop_toTopOf="parent"
-            tools:text="목적 키워드" />
+            app:layout_constraintTop_toBottomOf="@id/gl_top" />
 
         <TextView
             android:id="@+id/tv_join_group_search_name"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
+            android:layout_marginEnd="20dp"
+            android:maxLines="2"
             android:text="@{joinGroupSearch.name}"
             android:textAppearance="@style/TextAppearance.Pingle.Body.Med.16"
             android:textColor="@color/white"
             app:layout_constraintBottom_toBottomOf="@id/tv_join_group_search_tag"
+            app:layout_constraintEnd_toStartOf="@id/iv_join_group_search_check"
             app:layout_constraintStart_toEndOf="@id/tv_join_group_search_tag"
             app:layout_constraintTop_toTopOf="@id/tv_join_group_search_tag"
             tools:text="단체 이름" />
@@ -63,7 +73,7 @@
             android:id="@+id/iv_join_group_search_check"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="@dimen/spacing10"
+            android:layout_marginEnd="10dp"
             android:src="@{joinGroupSearch.isSelected ? @drawable/ic_all_check_selected_24 : @drawable/ic_all_check_default_24}"
             app:layout_constraintBottom_toBottomOf="@id/tv_join_group_search_tag"
             app:layout_constraintEnd_toStartOf="@id/gl_end"


### PR DESCRIPTION
## Related issue 🛠
- closed #242 

## Work Description ✏️
- 스플래시 - 로그인 이후 앱 재실행시 (온보딩X) 입장방식선택으로 가야됌
- 온보딩(기존단체입장) - 단체 키워드 정렬 안되어있음(왼쪽에 붙어있어요)
- 온보딩(신규단체개설) - 안내페이지 갔다 돌아오면 중복확인 스낵바 나옴..
- 온보딩(신규단체개설) - 안내페이지, 뒤로가기 시 chip 선택해제 등 데이터 저장..
- 전체적으로 단체명 2줄 확인
- 데이터 텍소노미 스크롤 시점으로 변경

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅
- 온보딩(기존단체입장) - 직접 입력할 때 → 흰색, 복사할 때 → 검정색
저빼고 된다니깐 넘어갈게요! 제 실기기 문제인가봐요 ㅠ

## To Reviewers 📢
